### PR TITLE
[FEAT] Issue Page pagination implemented #1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tanstack/react-query": "^4.3.9",
         "@tanstack/react-query-devtools": "^4.3.9",
         "axios": "^0.27.2",
+        "date-fns": "^2.29.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.4.0",
@@ -840,6 +841,18 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
       "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2442,6 +2455,11 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
       "dev": true
+    },
+    "date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@tanstack/react-query": "^4.3.9",
     "@tanstack/react-query-devtools": "^4.3.9",
     "axios": "^0.27.2",
+    "date-fns": "^2.29.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.4.0",

--- a/src/atoms/reposState.ts
+++ b/src/atoms/reposState.ts
@@ -14,8 +14,8 @@ const localStorageEffect =
     });
   };
 
-export const savedReposState = atom({
-  key: "savedReposState",
+export const savedRepoNames = atom({
+  key: "savedRepoNames",
   default: [],
   effects: [localStorageEffect("repos")],
 });

--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -1,40 +1,63 @@
 import styled from "styled-components";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import SearchInputBox from "../UI/SearchInputBox";
 import RepoSearchResultDropdown from "./SearchRepoResult";
 import useReposQuery from "../../fetch_modules/repos/useReposQuery";
+import { theme } from "../../styles/theme";
+import useDetectOutsideClick from "../../UI_hooks/useDetectOutsideClick";
 
 export default function GNB() {
-  const { setSearchQuery, repos, ...fetchState } = useReposQuery();
-
+  const { setSearchQuery, searchedRepos: repos, ...fetchState } = useReposQuery();
+  const outsideClickRef = useRef(null);
   const [isShowingSearchResult, setIsShowingSearchResult] = useState(false);
-
   const onSearchSubmit = (searchString: string) => {
     setSearchQuery(encodeURIComponent(searchString));
     setIsShowingSearchResult(true);
   };
+  useDetectOutsideClick([outsideClickRef], () => setIsShowingSearchResult(false));
 
   return (
     <Container>
+      {isShowingSearchResult && <Veil />}
       <h2>Github Issues Newsstand</h2>
-      <SearchInputBox onSubmitHandler={onSearchSubmit} />
-      {isShowingSearchResult && (
-        <RepoSearchResultDropdown
-          repos={repos}
-          fetchState={fetchState}
-          close={() => setIsShowingSearchResult(false)}
+      <InputBoxWrapper ref={outsideClickRef}>
+        <SearchInputBox
+          onSubmitHandler={onSearchSubmit}
+          closeResults={() => setIsShowingSearchResult(false)}
         />
-      )}
+        {isShowingSearchResult && (
+          <RepoSearchResultDropdown
+            repos={repos}
+            fetchState={fetchState}
+            close={() => setIsShowingSearchResult(false)}
+          />
+        )}
+      </InputBoxWrapper>
     </Container>
   );
 }
 
 const Container = styled.header`
+  background-color: ${theme.primaryColor};
+  color: white;
   position: relative;
   height: 3rem;
-  border-bottom: 1px solid black;
   padding: 0.5rem 2rem;
   display: flex;
   justify-content: space-between;
   align-items: center;
+`;
+
+const Veil = styled.div`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  height: calc(100vh - 3rem);
+  background-color: rgba(0, 0, 0, 0.5);
+`;
+
+const InputBoxWrapper = styled.div`
+  width: 50%;
+  height: 100%;
 `;

--- a/src/components/GNB/SearchRepoResult.tsx
+++ b/src/components/GNB/SearchRepoResult.tsx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import { Repository } from "../../types/data";
 import { useRef, useState } from "react";
 import { useRecoilState } from "recoil";
-import { savedReposState } from "../../atoms/reposState";
+import { savedRepoNames } from "../../atoms/reposState";
 import useIntersectionObserver from "../../UI_hooks/useIntersectionObserver";
 import useDetectOutsideClick from "../../UI_hooks/useDetectOutsideClick";
 import LoadingSpinner from "../UI/LoadingSpinner";
@@ -31,14 +31,15 @@ export default function RepoSearchResultDropdown({
   const { fetchNextPage, isLoading, isFetchingNextPage, hasNextPage, isError, error } = fetchState;
   const bottomDetectorRef = useRef(null);
   const rootRef = useRef(null);
-  const [savedRepos, setSavedRepos] = useRecoilState(savedReposState);
+  const [savedRepos, setSavedRepos] = useRecoilState(savedRepoNames);
   const [alert, setAlert] = useState({ isShowing: false, message: "" });
-
-  const saveRepo = (repo: Repository) =>
-    savedRepos.length < 4
-      ? setSavedRepos([...savedRepos, repo])
-      : setAlert({ isShowing: true, message: "리포지토리 저장 가능 한도(4개)를 초과했어요." });
-
+  console.log(alert);
+  const saveRepo = (repo: Repository) => {
+    if (savedRepos.length < 4) {
+      setSavedRepos([...savedRepos, repo]);
+      close();
+    } else setAlert({ isShowing: true, message: "리포지토리 저장 가능 한도(4개)를 초과했어요." });
+  };
   useIntersectionObserver(
     bottomDetectorRef,
     rootRef,
@@ -49,33 +50,44 @@ export default function RepoSearchResultDropdown({
     [repos]
   );
 
-  useDetectOutsideClick([rootRef], () => close());
-
   return (
     <Container ref={rootRef}>
-      {repos &&
+      {repos && repos.length > 0 ? (
         repos.map((repo) => (
           <Item key={repo.id}>
-            <h3>{repo.fullName}</h3>
-            <div>{repo.description}</div>
-            <div>
-              <span>{repo.stargazers_count}</span>
-              <span>{repo.language}</span>
-              <span>{repo.license}</span>
-              <span>{repo.updated_at.toLocaleDateString()}</span>
-            </div>
-            <SaveButton onClick={() => saveRepo(repo)}>
+            <ItemInfo>
+              <h3>{repo.fullName}</h3>
+              <div>{repo.description}</div>
+              <ItemDetails>
+                <span>⭐ {repo.stargazers_count}</span>
+                <span>|</span>
+                <span>{repo.language}</span>
+                <span>|</span>
+                <span>{repo.license}</span>
+                <span>|</span>
+                <span>Last Update: {repo.updated_at.toLocaleDateString()}</span>
+              </ItemDetails>
+            </ItemInfo>
+            <SaveButton
+              onClick={(event) => {
+                event.stopPropagation();
+                saveRepo(repo);
+              }}
+            >
               <span> Save </span>
               <SaveRepoIcon />
             </SaveButton>
           </Item>
-        ))}
-      {hasNextPage && !isFetchingNextPage && <BottomDetector ref={bottomDetectorRef} />}
-      {isLoading && (
+        ))
+      ) : isLoading ? (
         <SpinnerWrapper>
           <LoadingSpinner color={theme.primaryColor} backgroundColor={theme.backgroundColor} />
         </SpinnerWrapper>
+      ) : (
+        <Status>No Results</Status>
       )}
+      {hasNextPage && !isFetchingNextPage && <BottomDetector ref={bottomDetectorRef} />}
+
       {isFetchingNextPage && <div>Loading...</div>}
       {alert.isShowing && (
         <AlertDialog
@@ -91,15 +103,15 @@ export default function RepoSearchResultDropdown({
 const Container = styled.ul`
   position: absolute;
   width: 80%;
-  height: 50rem;
+  height: 80vh;
   left: 10%;
   top: 100%;
   overflow-y: auto;
   overflow-x: hidden;
-  border: 1px solid ${theme.borderColor};
+  color: ${theme.fontColor};
   background-color: white;
   li {
-    border-bottom: 1px solid ${theme.borderColor};
+    border-bottom: 1px solid ${theme.primaryColor};
   }
   li:last-child {
     border-bottom: none;
@@ -107,11 +119,29 @@ const Container = styled.ul`
 `;
 const Item = styled.li`
   width: 100%;
+  padding: 0.3rem 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+const ItemInfo = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+`;
+const ItemDetails = styled.div`
+  display: flex;
+  gap: 0.3rem;
 `;
 const SaveButton = styled.button`
-  border: 1px solid ${theme.borderColor};
+  border: 1px solid ${theme.primaryColor};
   border-radius: 5px;
   display: flex;
+  gap: 0.2rem;
+  width: 5rem;
+  height: 2rem;
+  color: ${theme.primaryColor};
 `;
 const SaveRepoIcon = styled(BsArrowRightCircle)``;
 
@@ -121,6 +151,17 @@ const BottomDetector = styled.div`
 `;
 
 const SpinnerWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Status = styled.div`
   width: 100%;
   height: 100%;
   display: flex;

--- a/src/components/RepositoriesNav.tsx
+++ b/src/components/RepositoriesNav.tsx
@@ -1,16 +1,22 @@
 import { useNavigate } from "react-router-dom";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
-import { savedReposState } from "../atoms/reposState";
+import { savedRepoNames } from "../atoms/reposState";
 import { theme } from "../styles/theme";
+import { IoIosClose } from "react-icons/io";
 
 export default function RepositoriesNav() {
-  const [savedRepos, setSavedRepos] = useRecoilState(savedReposState);
+  const [savedRepos, setSavedRepos] = useRecoilState(savedRepoNames);
   const navigate = useNavigate();
   return (
     <Container>
       {savedRepos.map((repo) => (
-        <Item onClick={() => navigate(`/${repo.id}`)}>{repo.fullName}</Item>
+        <Item key={repo.id} onClick={() => navigate(`/${repo.fullName}`)}>
+          {repo.fullName}
+          <CloseIcon
+            onClick={() => setSavedRepos(savedRepos.filter((_repo) => _repo.id !== repo.id))}
+          />
+        </Item>
       ))}
       <Item onClick={() => navigate(`/`)}>Show All</Item>
     </Container>
@@ -28,4 +34,10 @@ const Container = styled.nav`
 const Item = styled.li`
   border: 1px solid ${theme.borderColor};
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.2rem;
 `;
+
+const CloseIcon = styled(IoIosClose)``;

--- a/src/components/UI/Button.tsx
+++ b/src/components/UI/Button.tsx
@@ -7,13 +7,18 @@ export default function Button(props: ComponentProps<any>) {
 }
 
 const Container = styled.button`
-  color: ${theme.fontColor};
-  width: 10rem;
-  height: 2rem;
+  color: ${theme.primaryColor};
+  padding: 0.2rem 0.5rem;
+  border: 1px solid ${theme.primaryColor};
+  background-color: ${theme.backgroundColor};
+  border-radius: 10px;
   cursor: pointer;
   display: flex;
   justify-content: center;
   align-items: center;
+  transition: background-color 0.1s, color 0.1s;
   &:hover {
+    background-color: ${theme.primaryColor};
+    color: white;
   }
 `;

--- a/src/components/UI/Chip.tsx
+++ b/src/components/UI/Chip.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from "react";
+import styled from "styled-components";
+import { theme } from "../../styles/theme";
+
+export default function Chip({
+  children,
+  color,
+  className,
+}: {
+  children: ReactNode;
+  color: string;
+  className?: string;
+}) {
+  return (
+    <Container color={color} className={className}>
+      {children}
+    </Container>
+  );
+}
+
+const Container = styled.span<{ color: string }>`
+  background-color: ${(props) => props.color + "80"};
+  border-radius: 1rem;
+  padding: 0.15rem 0.4rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  white-space: pre;
+  &:hover {
+  }
+`;

--- a/src/components/UI/SearchInputBox.tsx
+++ b/src/components/UI/SearchInputBox.tsx
@@ -6,6 +6,7 @@ const SearchInputBox = ({
   onSubmitHandler,
 }: {
   onSubmitHandler: (searchString: string) => void;
+  closeResults: () => void;
 }) => {
   const [searchString, setSearchString] = useState("");
   const handleOnChangeSearchInput = (event: React.ChangeEvent<HTMLInputElement>) =>
@@ -28,25 +29,28 @@ const SearchInputBox = ({
 };
 
 const InputBox = styled.div`
-  width: 50%;
+  width: 100%;
   height: 100%;
   display: flex;
   align-items: center;
+  gap: 0.5rem;
 `;
 const SearchInput = styled.input`
   width: 80%;
   height: 100%;
-  border: 1px solid black;
+  border: 1px solid white;
   border-radius: 5px;
+  padding: 0.5rem;
 `;
 const SubmitSearch = styled.button`
   width: 2rem;
   height: 100%;
-  border: 1px solid black;
+  border: 1px solid white;
   border-radius: 5px;
   * {
     width: 100%;
     height: 100%;
+    color: white;
   }
 `;
 

--- a/src/components/UI/TodoSkeleton.tsx
+++ b/src/components/UI/TodoSkeleton.tsx
@@ -1,0 +1,32 @@
+import styled from "styled-components";
+import { Container as TodoStyle } from "../components/Todo";
+
+export default function TodoSkeleton({ numOfItems }: { numOfItems: number }) {
+  return (
+    <>
+      {new Array(numOfItems).fill(0).map((_, index) => (
+        <Skeleton key={index}>
+          <SkeletonTextTitle />
+          <SkeletonTextInfo />
+        </Skeleton>
+      ))}
+    </>
+  );
+}
+
+const Skeleton = styled(TodoStyle)`
+  height: 5rem;
+  gap: 0.5rem;
+`;
+
+const SkeletonTextTitle = styled.div`
+  width: 100%;
+  height: 2.5rem;
+  animation: skeleton-gradient 1s infinite;
+`;
+const SkeletonTextInfo = styled.div`
+  width: 30%;
+  height: 1rem;
+  align-self: flex-end;
+  animation: skeleton-gradient 1s infinite;
+`;

--- a/src/fetch_modules/issues/parseIssueData.ts
+++ b/src/fetch_modules/issues/parseIssueData.ts
@@ -1,16 +1,22 @@
-import { Issue } from "../../types/data";
+import { Issue, IssueLabel } from "../../types/data";
 
-const parseIssueData = (data: any): Issue => ({
+const parseIssueData = (repoFullName: string, data: any): Issue => ({
   id: data.id,
+  repoFullName: repoFullName,
   number: Number(data.number),
   title: data.title,
   userName: data.user.login,
   state: data.state,
-  status: data.labels.status,
+  labels: data.labels.map((label: IssueLabel) => ({
+    id: label.id,
+    name: label.name,
+    color: label.color,
+    description: label.description,
+  })),
   created_at: new Date(data.created_at),
   updated_at: new Date(data.updated_at),
   comments: Number(data.comments),
-  url: data.url,
+  html_url: data.html_url,
 });
 
 export default parseIssueData;

--- a/src/fetch_modules/issues/useIssuesQuery.tsx
+++ b/src/fetch_modules/issues/useIssuesQuery.tsx
@@ -1,12 +1,50 @@
-import { useQuery } from "@tanstack/react-query";
+import {
+  QueryClient,
+  useInfiniteQuery,
+  useQueries,
+  useQuery,
+  useQueryClient,
+  UseQueryResult,
+} from "@tanstack/react-query";
 import { useRecoilValue } from "recoil";
-import { savedReposState } from "../../atoms/reposState";
+import { savedRepoNames } from "../../atoms/reposState";
+import { IssueOptions, IssueOpenOrClosedStatus, Issue } from "../../types/data";
 import useIssuesRequest from "./useIssuesRequest";
+import { ITEMS_PER_PAGE } from "../../consts/consts";
+import { useEffect, useState } from "react";
 
-export default function useIssuesQuery() {
-  const savedRepos = useRecoilValue(savedReposState);
-  const { getAllIssues } = useIssuesRequest();
-  const { data, isError } = useQuery(["issues"], () => getAllIssues(savedRepos));
-  const issues = data;
-  return { issues, isError };
+export default function useIssuesQuery(selectedOptions: IssueOptions) {
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const { selectedRepoName, openOrClosed, page } = selectedOptions;
+  const savedRepos = useRecoilValue(savedRepoNames);
+  const { getIssuesByRepoName } = useIssuesRequest();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const useAllIssueQueries = (page: number): UseQueryResult<Issue[]>[] =>
+    useQueries({
+      queries: savedRepos.map((repo) => ({
+        queryKey: ["issues", repo.fullName, openOrClosed, page],
+        queryFn: () => getIssuesByRepoName(repo.fullName, openOrClosed, page),
+        staleTime: Infinity,
+        retry: 1,
+        refetchOnWindowFocus: false,
+        keepPreviousData: true,
+      })),
+    });
+  const results = useAllIssueQueries(page);
+  const nextAllIssues = useAllIssueQueries(page + 1);
+
+  useEffect(() => {
+    if (selectedRepoName) {
+      const nextPageData =
+        nextAllIssues[savedRepos.findIndex((e) => e.fullName === selectedRepoName)]?.data;
+      if (nextPageData) setHasNextPage(nextPageData.length > 0);
+    } else {
+      setHasNextPage(
+        nextAllIssues.some((result) => (result?.data ? result?.data.length > 0 : false))
+      );
+    }
+  }, [results]);
+
+  return { results, isLoading, hasNextPage };
 }

--- a/src/fetch_modules/repos/useReposQuery.tsx
+++ b/src/fetch_modules/repos/useReposQuery.tsx
@@ -9,20 +9,20 @@ export default function useReposQuery() {
   const { searchRepos } = useReposRequest();
   const { fetchNextPage, isLoading, isFetchingNextPage, hasNextPage, isError, error, data } =
     useInfiniteQuery(
-      ["repos", searchQuery],
-      ({ pageParam = 0 }) => searchRepos(searchQuery, pageParam),
+      ["searchedRepos", searchQuery],
+      ({ pageParam = 1 }) => searchRepos(searchQuery, pageParam),
       {
         retry: 1,
         refetchOnWindowFocus: false,
         keepPreviousData: true,
         getNextPageParam: (lastPage, allPages) => {
-          console.log("lastPage", lastPage);
           return lastPage.length < ITEMS_PER_PAGE ? undefined : allPages.length + 1;
         },
       }
     );
   console.log(data);
-  const repos: Repository[] | undefined = data && data.pages ? data.pages.flat() : undefined;
+  const searchedRepos: Repository[] | undefined =
+    data && data.pages ? data.pages.flat() : undefined;
 
   return {
     searchQuery,
@@ -33,6 +33,6 @@ export default function useReposQuery() {
     hasNextPage,
     isError,
     error,
-    repos,
+    searchedRepos,
   };
 }

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -1,37 +1,236 @@
+import { useQueryClient, UseQueryResult } from "@tanstack/react-query";
+import { differenceInCalendarDays, differenceInHours } from "date-fns";
+import { useState } from "react";
 import { useParams } from "react-router-dom";
-import { useRecoilValue } from "recoil";
 import styled from "styled-components";
-import { savedReposState } from "../atoms/reposState";
+import Button from "../components/UI/Button";
+import Chip from "../components/UI/Chip";
+import LoadingSpinner from "../components/UI/LoadingSpinner";
 import useIssuesQuery from "../fetch_modules/issues/useIssuesQuery";
 import { theme } from "../styles/theme";
-import { Issue } from "../types/data";
+import { Issue, IssueOptions, IssueOpenOrClosedStatus, ISSUE_STATE } from "../types/data";
+
+const getTimePassedText = (today: Date, past: Date) => {
+  if (today instanceof Date === false || past instanceof Date === false) return undefined;
+  const differenceInDays = differenceInCalendarDays(today, past);
+  if (differenceInDays === 1) return "yesterday";
+  if (differenceInDays > 1) return differenceInDays + " days ago";
+  if (differenceInDays === 0) return differenceInHours(today, past) + " hours ago";
+};
 
 export default function IssuesPage() {
-  const { repositoryId } = useParams();
-  const { issues } = useIssuesQuery();
-  const savedRepos = useRecoilValue(savedReposState);
+  const { repoName } = useParams();
+  const [selectedOptions, setSelectedOptions] = useState<IssueOptions>({
+    selectedRepoName: repoName,
+    openOrClosed: ISSUE_STATE.OPEN,
+    page: 1,
+  });
 
+  const { results, hasNextPage } = useIssuesQuery(selectedOptions);
+  const today = new Date();
+  const queryClient = useQueryClient();
+
+  const toggleIssueStateFilter = (issueState: IssueOpenOrClosedStatus) => {
+    setSelectedOptions({ ...selectedOptions, openOrClosed: issueState, page: 1 });
+  };
+
+  const getIsLoading = (results: UseQueryResult[]) =>
+    results.length > 0 ? results.some((result) => result.isLoading) : false;
+
+  const getIssues = (results: UseQueryResult<Issue[]>[]): (Issue | undefined)[] => {
+    const allIssues = results.map((result) => result.data).flat();
+    return selectedOptions.selectedRepoName
+      ? queryClient.getQueryData([
+          "issues",
+          selectedOptions.selectedRepoName,
+          selectedOptions.openOrClosed,
+          selectedOptions.page,
+        ]) || []
+      : allIssues;
+  };
+
+  console.log(results);
   return (
     <Container>
-      {issues
-        ? repositoryId
-          ? issues[repositoryId].map((issue: Issue) => <Item>{issue.title}</Item>)
-          : Object.values(issues)
-              .flat()
-              .map((issue: Issue) => <Item>{issue.title}</Item>)
-        : ""}
+      <IssuesContainer>
+        <ToolBar>
+          <div>Issue State: </div>
+          <ChooseStateButtons>
+            <IssueStateButton
+              selected={selectedOptions.openOrClosed === ISSUE_STATE.OPEN}
+              onClick={() => toggleIssueStateFilter(ISSUE_STATE.OPEN)}
+            >
+              OPEN
+            </IssueStateButton>
+            <IssueStateButton
+              selected={selectedOptions.openOrClosed === ISSUE_STATE.CLOSED}
+              onClick={() => toggleIssueStateFilter(ISSUE_STATE.CLOSED)}
+            >
+              CLOSED
+            </IssueStateButton>
+          </ChooseStateButtons>
+        </ToolBar>
+        {results && getIsLoading(results) && "Loading..."}
+        {results &&
+          !getIsLoading(results) &&
+          getIssues(results)?.map(
+            (issue: Issue | undefined) =>
+              issue && (
+                <Item key={issue.id}>
+                  <a href={issue.html_url} target="blank">
+                    <TitleWrapper>
+                      <Title>{issue.title}</Title>
+                      {issue.labels.map((label) => (
+                        <IssueLabel key={label.id} color={"#" + label.color}>
+                          {label.name}
+                        </IssueLabel>
+                      ))}
+                    </TitleWrapper>
+                    <div>Repository: {issue.repoFullName}</div>
+                    <div>
+                      #{issue.number} opened {getTimePassedText(today, new Date(issue.created_at))}
+                    </div>
+                    <div>{issue.state}</div>
+                  </a>
+                </Item>
+              )
+          )}
+        <PageNav>
+          {selectedOptions.page > 0 && (
+            <PrevButton
+              onClick={() =>
+                setSelectedOptions({ ...selectedOptions, page: selectedOptions.page - 1 })
+              }
+            >
+              &lt; Previous Page
+            </PrevButton>
+          )}
+          current Page: {selectedOptions.page}
+          {hasNextPage && (
+            <NextButton
+              onClick={() =>
+                setSelectedOptions({ ...selectedOptions, page: selectedOptions.page + 1 })
+              }
+            >
+              Next Page &gt;
+            </NextButton>
+          )}
+        </PageNav>
+      </IssuesContainer>
     </Container>
   );
 }
 
 const Container = styled.main`
   width: 100%;
-  display: flex;
-  flex-direction: column;
+  padding: 1rem;
   max-height: 100%;
   overflow: auto;
 `;
+const ToolBar = styled.div`
+  display: flex;
+  gap: 1rem;
+  padding: 0.3rem 0.5rem;
+  align-items: center;
+`;
+const ChooseStateButtons = styled.div`
+  display: inline;
+  width: 10rem;
+  height: 2rem;
+  border: 1px solid ${theme.borderColor};
+  border-radius: 10px;
+  display: flex;
+  justify-content: stretch;
+  align-items: center;
+  overflow: hidden;
+
+  > * {
+    border-right: 1px solid ${theme.borderColor};
+  }
+  > *:last-child {
+    border-right: none;
+  }
+`;
+const IssueStateButton = styled.div<{ selected: boolean }>`
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 50%;
+  height: 100%;
+  cursor: pointer;
+  background-color: ${theme.shadowColor};
+  ${(props) =>
+    props.selected &&
+    `  
+  box-shadow: inset 1px 2px 5px #777;
+  background: #e5e5e5;
+  `}
+`;
+const IssuesContainer = styled.div`
+  width: 90%;
+  border: 1px solid ${theme.borderColor};
+  border-radius: 5px;
+  margin: auto;
+  > * {
+    border-bottom: 0.5px solid ${theme.borderColor};
+    padding: 0.5rem;
+  }
+  > *:last-child {
+    border-bottom: none;
+  }
+`;
+
+const SpinnerWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
 
 const Item = styled.li`
-  border: 0.5px solid ${theme.borderColor};
+  a {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    * {
+      line-height: 1.1;
+    }
+  }
+`;
+
+const TitleWrapper = styled.div`
+  word-wrap: break-word;
+`;
+const Title = styled.h3`
+  display: inline;
+  max-width: 70%;
+`;
+
+const IssueLabel = styled(Chip)`
+  display: inline-block;
+  margin: 0.2rem 0.25rem;
+`;
+
+const PageNav = styled.div`
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  padding: 0.5rem 2rem;
+`;
+
+const PrevButton = styled(Button)`
+  position: absolute;
+  left: 1rem;
+  font-size: 0.8rem;
+`;
+const NextButton = styled(Button)`
+  position: absolute;
+  right: 1rem;
+  font-size: 0.8rem;
 `;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,7 +9,7 @@ export default function Router() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route path="" element={<IssuesPage />} />
-          <Route path=":repositoryId" element={<IssuesPage />} />
+          <Route path=":repoName" element={<IssuesPage />} />
         </Route>
         <Route path="*" element={<PageNotFound />} />
       </Routes>

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -23,11 +23,11 @@ export const GlobalStyle = createGlobalStyle`
 }
 a {
   font-weight: 500;
-  color: #646cff;
+  color: inherit;
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: ${theme.primaryColor};
 }
 
 h1 {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,6 +1,8 @@
 export const theme = {
   primaryColor: "#646cff",
+  primaryDarkColor: "#5259db",
   fontColor: "#242424",
   borderColor: "#242424",
   backgroundColor: "#ffffff",
+  shadowColor: "#ebebeb",
 };

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -1,15 +1,20 @@
 export type Issue = {
   id: string;
+  repoFullName: string;
   number: number;
   title: string;
   userName: string;
-  state: "open" | "closed";
-  status: string;
+  state: IssueOpenOrClosedStatus;
+  labels: IssueLabel[];
   created_at: Date;
   updated_at: Date;
   comments: number;
-  url: string;
+  html_url: string;
 };
+export type Issues = { [id: string]: Issue[] | [] };
+
+export const ISSUE_STATE = { OPEN: "open", CLOSED: "closed" } as const;
+export type IssueOpenOrClosedStatus = typeof ISSUE_STATE[keyof typeof ISSUE_STATE];
 
 export type Repository = {
   id: string;
@@ -19,4 +24,17 @@ export type Repository = {
   language: string;
   license: string;
   updated_at: Date;
+};
+
+export type IssueLabel = {
+  id: number;
+  name: string;
+  color: string;
+  description: string;
+};
+
+export type IssueOptions = {
+  selectedRepoName: string | undefined;
+  openOrClosed: IssueOpenOrClosedStatus;
+  page: number;
 };


### PR DESCRIPTION
이슈 페이지의 이슈들을 페이지네이션 하였습니다.

## 수정사항
1. Fetch module:
- 기존 fetching module 구조: Request hook 에서 local storage(및 recoil) 에 저장된 repo들 마다의 issue 데이터를 가져와 repoName을 키로 갖는 object를 구성하는 queryFn을 useQuery 에 주입
- 수정 후 fetching module 구조: React Query 에서 제공하는 useQueries를 사용하여 데이터들을 리포지토리/open or close 상태/페이지 별로 각각 별개의 query data로 저장

2. 이슈들 및 전반에 거친 UI 작성
