### PR TITLE
[FIX] RepositoryNav 리포 선택 라우팅 문제 해결

### DIFF
--- a/src/components/GNB/GNB.tsx
+++ b/src/components/GNB/GNB.tsx
@@ -5,11 +5,13 @@ import RepoSearchResultDropdown from "./SearchRepoResult";
 import useReposQuery from "../../fetch_modules/repos/useReposQuery";
 import { theme } from "../../styles/theme";
 import useDetectOutsideClick from "../../UI_hooks/useDetectOutsideClick";
+import { useNavigate } from "react-router-dom";
 
 export default function GNB() {
   const { setSearchQuery, searchedRepos: repos, ...fetchState } = useReposQuery();
   const outsideClickRef = useRef(null);
   const [isShowingSearchResult, setIsShowingSearchResult] = useState(false);
+  const navigate = useNavigate();
   const onSearchSubmit = (searchString: string) => {
     setSearchQuery(encodeURIComponent(searchString));
     setIsShowingSearchResult(true);
@@ -19,7 +21,7 @@ export default function GNB() {
   return (
     <Container>
       {isShowingSearchResult && <Veil />}
-      <h2>Github Issues Newsstand</h2>
+      <Title onClick={() => navigate("/")}>Github Issues Newsstand</Title>
       <InputBoxWrapper ref={outsideClickRef}>
         <SearchInputBox
           onSubmitHandler={onSearchSubmit}
@@ -57,6 +59,9 @@ const Veil = styled.div`
   background-color: rgba(0, 0, 0, 0.5);
 `;
 
+const Title = styled.h2`
+  cursor: pointer;
+`;
 const InputBoxWrapper = styled.div`
   width: 50%;
   height: 100%;

--- a/src/components/RepositoriesNav.tsx
+++ b/src/components/RepositoriesNav.tsx
@@ -11,10 +11,18 @@ export default function RepositoriesNav() {
   return (
     <Container>
       {savedRepos.map((repo) => (
-        <Item key={repo.id} onClick={() => navigate(`/${repo.fullName}`)}>
+        <Item
+          key={repo.id}
+          onClick={(event) => {
+            navigate(`/${repo.id}`);
+          }}
+        >
           {repo.fullName}
-          <CloseIcon
-            onClick={() => setSavedRepos(savedRepos.filter((_repo) => _repo.id !== repo.id))}
+          <RemoveIcon
+            onClick={(event) => {
+              event.stopPropagation();
+              setSavedRepos(savedRepos.filter((_repo) => _repo.id !== repo.id));
+            }}
           />
         </Item>
       ))}
@@ -40,4 +48,4 @@ const Item = styled.li`
   padding: 0.2rem;
 `;
 
-const CloseIcon = styled(IoIosClose)``;
+const RemoveIcon = styled(IoIosClose)``;

--- a/src/fetch_modules/issues/useIssuesRequest.tsx
+++ b/src/fetch_modules/issues/useIssuesRequest.tsx
@@ -15,29 +15,5 @@ export default function useIssuesRequest() {
       )
       .then((response) => response.data.map((data: any) => parseIssueData(repoFullName, data)));
 
-  // const getAllIssues = async (
-  //   repos: Repository[],
-  //   openOrClose: IssueOpenOrClosedStatus,
-  //   page: number
-  // ) => {
-  //   const results = await Promise.allSettled(
-  //     repos.map(
-  //       (repo) =>
-  //         new Promise<Issue[]>((resolve) =>
-  //           resolve(getIssuesByRepoName(repo.fullName, openOrClose, page))
-  //         )
-  //     )
-  //   );
-  //   const issues = results.reduce(
-  //     (prev, result, index) => ({
-  //       ...prev,
-  //       [repos[index].id]: result.status === "fulfilled" ? result.value : [],
-  //     }),
-  //     {} as Issues
-  //   );
-
-  //   return issues;
-  // };
-
   return { getIssuesByRepoName };
 }

--- a/src/fetch_modules/repos/useReposQuery.tsx
+++ b/src/fetch_modules/repos/useReposQuery.tsx
@@ -20,7 +20,7 @@ export default function useReposQuery() {
         },
       }
     );
-  console.log(data);
+
   const searchedRepos: Repository[] | undefined =
     data && data.pages ? data.pages.flat() : undefined;
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -9,7 +9,7 @@ export default function Router() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route path="" element={<IssuesPage />} />
-          <Route path=":repoName" element={<IssuesPage />} />
+          <Route path=":repoId" element={<IssuesPage />} />
         </Route>
         <Route path="*" element={<PageNotFound />} />
       </Routes>

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -17,7 +17,7 @@ export const ISSUE_STATE = { OPEN: "open", CLOSED: "closed" } as const;
 export type IssueOpenOrClosedStatus = typeof ISSUE_STATE[keyof typeof ISSUE_STATE];
 
 export type Repository = {
-  id: string;
+  id: number;
   fullName: string;
   description: string;
   stargazers_count: number;
@@ -34,7 +34,7 @@ export type IssueLabel = {
 };
 
 export type IssueOptions = {
-  selectedRepoName: string | undefined;
+  selectedRepoId: string | undefined;
   openOrClosed: IssueOpenOrClosedStatus;
   page: number;
 };

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,0 +1,6 @@
+export const sortByDate = (data: any[], key: string, order: "asc" | "desc") =>
+  data.sort((a, b) =>
+    order === "asc"
+      ? new Date(a[key]).getTime() - new Date(b[key]).getTime()
+      : new Date(b[key]).getTime() - new Date(a[key]).getTime()
+  );


### PR DESCRIPTION
#3 에 대한 문제 해결

## 수정 사항
- repository id 를 라우팅 parameter 및 캐시 데이터의 query key 로 변경
- id의 자료형 불일치 문제 해결: local storage 에서 parsing 될 시에는 number 로 저장되나, routing parameter 로 받는 id는 string이어서, 일치하는 데이터를 찾는 함수(getQueryData 및 getHasNextPage) 에 Number(id) 로 타입 변환
