### PR TITLE
[FEAT] 반응형 UI 작업 #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
 # github-issues-newsstand
+
 Search and subscribe to github repositories and see their issues at once
 
 # Objectives
+
 - GitHub의 Public Repository를 검색 및 등록하여 Issue들을 모아서 볼 수 있다.
 
-# Project Plan 
+# Project Plan
 
 ## State Management
 
-RepoSearchText: string -> GNB component state
+RepoSearchText: string -> TopNav component state
 
 RepoSearchResult: Repository[] -> React-Query
 
 SavedRepos: Repository[]<max:4> -> LocalStorage & Global(Recoil)
 
 Issues: {
-	[repository]: Issue[]
-	} -> React-Query
+[repository]: Issue[]
+} -> React-Query
 
 SortedIssues: Object.values(Issues).flat().reduce()
 
-## UI 
+## UI
 
 <img width="825" alt="Screen Shot 2022-09-23 at 4 03 40 AM" src="https://user-images.githubusercontent.com/69628701/191830897-68a4a9f8-cbd4-4033-aacb-f76905fe9d5c.png">
-
 
 ## Data Types
 

--- a/src/components/Issues/IssueItem.tsx
+++ b/src/components/Issues/IssueItem.tsx
@@ -1,5 +1,6 @@
 import { differenceInCalendarDays, differenceInHours } from 'date-fns';
 import styled from 'styled-components';
+import { MOBILE_WIDTH } from '../../consts/consts';
 import { Issue } from '../../types/data';
 import Chip from '../UI_common/Chip';
 
@@ -65,6 +66,9 @@ const Container = styled.li<{ backgroundColor?: string }>`
     * {
       line-height: 1.1;
     }
+  }
+  @media (max-width: ${MOBILE_WIDTH}px) {
+    font-size: 0.8rem;
   }
 `;
 

--- a/src/components/Issues/IssuesBox.tsx
+++ b/src/components/Issues/IssuesBox.tsx
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
 import { theme } from '../../styles/theme';
-import { IssueOpenOrClosedState, ISSUE_STATE } from '../../types/data';
 import { useState } from 'react';
 import useIssuesQuery from '../../fetch_modules/issues/useIssuesQuery';
 import { BsArrowsAngleExpand } from 'react-icons/bs';
 import IssuesToolbarSection from './IssuesToolbarSection';
 import IssuesSection from './IssuesSection';
 import PageNavSection from './PageNavSection';
+import { ISSUE_STATE, MOBILE_WIDTH, VIEW_MODE } from '../../consts/consts';
+import { IssueOpenOrClosedState, ViewMode } from '../../types/states';
 
 export type IssueOptions = {
   openOrClosed: IssueOpenOrClosedState;
@@ -15,12 +16,14 @@ export type IssueOptions = {
 
 export default function IssuesBox({
   repoName,
-  expanded,
+  isExpanded,
+  viewMode,
   repoIndex,
   onExpandCallback,
 }: {
   repoName: string | undefined;
-  expanded: boolean;
+  isExpanded: boolean;
+  viewMode: ViewMode;
   repoIndex: number;
   onExpandCallback?: () => void;
 }) {
@@ -48,8 +51,8 @@ export default function IssuesBox({
       <ErrorMessage>데이터를 가져오는데 문제가 있습니다.</ErrorMessage>
     </Container>
   ) : (
-    <Container>
-      <SubContainer expanded={expanded} index={repoIndex}>
+    <Container isExpanded={isExpanded} viewMode={viewMode}>
+      <SubContainer isExpanded={isExpanded} index={repoIndex}>
         <TitleSection color={theme.repoColor[repoIndex]}>
           <RepoTitle>{repoName}</RepoTitle>
           {onExpandCallback && (
@@ -80,12 +83,29 @@ const ErrorMessage = styled.div`
   justify-content: center;
   align-items: center;
 `;
-const Container = styled.div`
+const Container = styled.div<{ isExpanded?: boolean; viewMode?: ViewMode }>`
   width: 100%;
   overflow: hidden;
+  transition: height 0.3s linear;
+
+  @media (min-width: ${MOBILE_WIDTH}px) {
+    height: ${(props) =>
+      props.viewMode === VIEW_MODE.MULTIPLE
+        ? 'calc((100vh - 10rem) / 2)'
+        : 'calc(100vh - 10rem)'};
+  }
+
+  @media (max-width: ${MOBILE_WIDTH}px) {
+    height: ${(props) =>
+      props.viewMode === VIEW_MODE.MULTIPLE
+        ? props.isExpanded
+          ? '80vh'
+          : '40vh'
+        : '100%'};
+  }
 `;
 
-const SubContainer = styled.div<{ expanded: boolean; index: number }>`
+const SubContainer = styled.div<{ isExpanded: boolean; index: number }>`
   border: 1px solid ${theme.borderColor};
   border-radius: 5px;
   width: 100%;
@@ -98,31 +118,35 @@ const SubContainer = styled.div<{ expanded: boolean; index: number }>`
   > *:last-child {
     border-bottom: none;
   }
-  ${(props) =>
-    props.expanded &&
-    `
-    position: absolute;
-    z-index: 10;
-    background-color: ${theme.backgroundColor};
-    ${props.index === 0 || props.index === 2 ? 'left: 0; ' : 'right: 0;'}
-    ${props.index === 0 || props.index === 1 ? 'top: 0; ' : 'bottom: 0;'}
-    animation: expand 0.2s linear forwards;
-  `}
-  @keyframes expand {
-    0% {
-      width: 49%;
-      height: 49%;
-    }
-    100% {
-      width: 100%;
-      height: 100%;
+
+  @media (min-width: ${MOBILE_WIDTH}px) {
+    ${(props) =>
+      props.isExpanded &&
+      `
+      position: absolute;
+      z-index: 10;
+      background-color: ${theme.backgroundColor};
+      ${props.index === 0 || props.index === 2 ? 'left: 0; ' : 'right: 0;'}
+      ${props.index === 0 || props.index === 1 ? 'top: 0; ' : 'bottom: 0;'}
+      animation: expand 0.2s linear forwards;`}
+
+    @keyframes expand {
+      0% {
+        width: 49%;
+        height: 49%;
+      }
+      100% {
+        width: 100%;
+        height: 100%;
+      }
     }
   }
 `;
 
 const TitleSection = styled.section`
   width: 100%;
-  height: 2rem;
+  min-height: 1.4375rem;
+  height: 1.4375rem;
   padding: 0 0.5rem;
   display: flex;
   justify-content: space-between;

--- a/src/components/Issues/IssuesToolbarSection.tsx
+++ b/src/components/Issues/IssuesToolbarSection.tsx
@@ -1,7 +1,8 @@
 import { Dispatch } from 'react';
 import styled from 'styled-components';
+import { ISSUE_STATE } from '../../consts/consts';
 import { theme } from '../../styles/theme';
-import { IssueOpenOrClosedState, ISSUE_STATE } from '../../types/data';
+import { IssueOpenOrClosedState } from '../../types/states';
 import { IssueOptions } from './IssuesBox';
 
 export default function IssuesToolbarSection({

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { Outlet } from 'react-router-dom';
 import Main from './Main';
-import GNB from './GNB/GNB';
+import TopNav from './TopNav/TopNav';
 import RepositoriesNav from './RepositoriesNav';
 import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -12,7 +12,7 @@ export default function Layout() {
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>
         <ReactQueryDevtools />
-        <GNB />
+        <TopNav />
         <RepositoriesNav />
         <Main>
           <Outlet />

--- a/src/components/RepositoriesNav.tsx
+++ b/src/components/RepositoriesNav.tsx
@@ -5,6 +5,7 @@ import { saveReposState } from '../atoms/reposState';
 import { theme } from '../styles/theme';
 import { IoIosClose } from 'react-icons/io';
 import Button from './UI_common/Button';
+import { MOBILE_WIDTH } from '../consts/consts';
 
 export default function RepositoriesNav() {
   const [savedRepos, setSavedRepos] = useRecoilState(saveReposState);
@@ -29,13 +30,13 @@ export default function RepositoriesNav() {
           />
         </Item>
       ))}
-      <ShowAllButton onClick={() => navigate(`/`)}>Show All</ShowAllButton>
+      <ShowAllButton onClick={() => navigate(`/`)} />
     </Container>
   );
 }
 
 const Container = styled.nav`
-  min-height: 3rem;
+  height: 3rem;
   width: 100%;
   justify-content: flex-start;
   display: flex;
@@ -46,6 +47,14 @@ const Container = styled.nav`
 const ShowAllButton = styled(Button)`
   width: 18%;
   margin-left: auto;
+  &::before {
+    content: 'Show All';
+  }
+  @media (max-width: ${MOBILE_WIDTH}px) {
+    &::before {
+      content: 'All';
+    }
+  }
 `;
 const Item = styled.li<{ color: string }>`
   width: 18%;
@@ -57,12 +66,19 @@ const Item = styled.li<{ color: string }>`
   align-items: center;
   justify-content: space-between;
   padding: 0.2rem 0.5rem;
+  @media (max-width: ${MOBILE_WIDTH}px) {
+    padding: 0.2rem 0.2rem;
+    font-size: 0.8rem;
+  }
 `;
 const RepoName = styled.div`
   width: 100%;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  @media (max-width: ${MOBILE_WIDTH}px) {
+    text-overflow: inherit;
+  }
 `;
 
 const RemoveIcon = styled(IoIosClose)`

--- a/src/components/TopNav/RepoItem.tsx
+++ b/src/components/TopNav/RepoItem.tsx
@@ -1,0 +1,70 @@
+import { BsArrowRightCircle } from 'react-icons/bs';
+import styled from 'styled-components';
+import { Repository } from '../../types/data';
+import Button from '../UI_common/Button';
+
+export default function RepoItem({
+  repo,
+  saveRepo,
+}: {
+  repo: Repository;
+  saveRepo: (repo: Repository) => void;
+}) {
+  return (
+    <Container>
+      <ItemInfo>
+        <h3>{repo.fullName}</h3>
+        <div>{repo.description}</div>
+        <ItemDetails>
+          {repo.stargazers_count && <Detail>⭐ {repo.stargazers_count}</Detail>}
+          {repo.language && <Detail>{repo.language}</Detail>}
+          {repo.license && <Detail>{repo.license}</Detail>}
+          <Detail>Last Update: {repo.updated_at.toLocaleDateString()}</Detail>
+        </ItemDetails>
+      </ItemInfo>
+      <SaveButton
+        onClick={(event: React.MouseEvent) => {
+          event.stopPropagation();
+          saveRepo(repo);
+        }}
+      >
+        <span> Save </span>
+        <SaveRepoIcon />
+      </SaveButton>
+    </Container>
+  );
+}
+
+const Container = styled.li`
+  width: 100%;
+  padding: 0.3rem 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  line-height: 120%;
+`;
+const ItemInfo = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+`;
+const ItemDetails = styled.div`
+  gap: 0.3rem;
+`;
+const Detail = styled.span`
+  &::after {
+    content: ' | ';
+  }
+  &:last-child::after {
+    content: '';
+  }
+`;
+const SaveButton = styled(Button)`
+  border-radius: 5px;
+  display: flex;
+  gap: 0.2rem;
+  width: 5rem;
+  height: 2rem;
+`;
+const SaveRepoIcon = styled(BsArrowRightCircle)``;

--- a/src/components/TopNav/SearchInputBox.tsx
+++ b/src/components/TopNav/SearchInputBox.tsx
@@ -1,19 +1,21 @@
 import styled from 'styled-components';
 import { AiOutlineSearch } from 'react-icons/ai';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { MdCancel } from 'react-icons/md';
-import Button from './Button';
+import Button from '../UI_common/Button';
 import { theme } from '../../styles/theme';
 
 const SearchInputBox = ({
-  handleOnSearch,
-  handleOnSubmit,
-  handleOnFocus,
+  handleOnSearchFromParent,
+  handleOnChangeFromParent,
+  handleOnSubmitFromParent,
+  handleOnFocusFromParent,
   placeholder,
 }: {
-  handleOnSearch: (searchString: string) => void;
-  handleOnSubmit: (searchString: string) => void;
-  handleOnFocus: () => void;
+  handleOnSearchFromParent: (searchString: string) => void;
+  handleOnChangeFromParent: (searchString: string) => void;
+  handleOnSubmitFromParent: (searchString: string) => void;
+  handleOnFocusFromParent: () => void;
   placeholder: string;
 }) => {
   const [searchString, setSearchString] = useState('');
@@ -21,25 +23,33 @@ const SearchInputBox = ({
   const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchString(event.target.value);
   };
+  const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (isAutoSearchOn) handleOnSearch(searchString);
+    if (isAutoSearchOn) handleOnSearchFromParent(searchString);
+    handleOnChangeFromParent(searchString);
   }, [searchString]);
 
   return (
     <InputBox onSubmit={(event) => event.preventDefault()}>
       <InputWrapper>
         <SearchInput
+          ref={inputRef}
           type="text"
           id="search_string"
           placeholder={placeholder}
+          autoComplete="off"
           value={searchString}
           onChange={handleOnChange}
-          onFocus={handleOnFocus}
+          onFocus={handleOnFocusFromParent}
         />
         {searchString && (
           <IconWrapper>
-            <CancelIcon onClick={() => setSearchString('')} />
+            <CancelIcon
+              onClick={() => {
+                setSearchString('');
+              }}
+            />
           </IconWrapper>
         )}
         <AutoSearchToggleButton
@@ -53,7 +63,7 @@ const SearchInputBox = ({
       <SubmitSearch
         type="submit"
         onClick={() => {
-          handleOnSubmit(searchString);
+          handleOnSubmitFromParent(searchString);
         }}
       >
         <AiOutlineSearch />
@@ -67,11 +77,12 @@ const InputBox = styled.form`
   height: 100%;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
 `;
 
 const InputWrapper = styled.div`
-  width: 80%;
+  width: 100%;
   height: 100%;
   border: 1px solid white;
   border-radius: 5px;
@@ -88,7 +99,7 @@ const SearchInput = styled.input`
 `;
 
 const IconWrapper = styled.div`
-  width: 1rem;
+  width: 1.3rem;
   display: flex;
   align-items: center;
   margin-right: 0.5rem;

--- a/src/components/TopNav/TopNav.tsx
+++ b/src/components/TopNav/TopNav.tsx
@@ -1,16 +1,16 @@
 import styled from 'styled-components';
 import { useRef, useState } from 'react';
-import SearchInputBox from '../UI_common/SearchInputBox';
+import SearchInputBox from './SearchInputBox';
 import RepoSearchResultDropdown from './RepoSearchResult';
 import useReposQuery from '../../fetch_modules/repos/useReposQuery';
 import { theme } from '../../styles/theme';
 import useDetectOutsideClick from '../../UI_hooks/useDetectOutsideClick';
 import { useNavigate } from 'react-router-dom';
 import createDebouncedAction from '../../utils/debouncer';
-import { DEBOUNCER_DELAY_TIME } from '../../consts/consts';
+import { DEBOUNCER_DELAY_TIME, MOBILE_WIDTH } from '../../consts/consts';
 
-export default function GNB() {
-  const { setSearchQuery, searchedRepos: repos, ...fetchState } = useReposQuery();
+export default function TopNav() {
+  const { setSearchQuery, data: repos, ...fetchState } = useReposQuery();
   const outsideClickRef = useRef(null);
   const [isShowingSearchResult, setIsShowingSearchResult] = useState(false);
   const navigate = useNavigate();
@@ -28,11 +28,16 @@ export default function GNB() {
       <Title onClick={() => navigate('/')}>Github Issues Newsstand</Title>
       <InputBoxWrapper ref={outsideClickRef}>
         <SearchInputBox
-          handleOnSearch={(searchString) => setSearchWithDebouncer(searchString)}
-          handleOnSubmit={(searchString) =>
+          handleOnSearchFromParent={(searchString) =>
+            setSearchWithDebouncer(searchString)
+          }
+          handleOnSubmitFromParent={(searchString) =>
             setSearchQuery(encodeURIComponent(searchString))
           }
-          handleOnFocus={() => setIsShowingSearchResult(true)}
+          handleOnFocusFromParent={() => setIsShowingSearchResult(true)}
+          handleOnChangeFromParent={(searchString) =>
+            setIsShowingSearchResult(!!searchString)
+          }
           placeholder="Search Repositories"
         />
         {isShowingSearchResult && (
@@ -56,6 +61,12 @@ const Container = styled.header`
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  @media (max-width: ${MOBILE_WIDTH}px) {
+    flex-direction: column;
+    height: fit-content;
+    gap: 0.3rem;
+  }
 `;
 
 const Veil = styled.div`
@@ -70,8 +81,16 @@ const Veil = styled.div`
 
 const Title = styled.h2`
   cursor: pointer;
+  height: 2rem;
 `;
 const InputBoxWrapper = styled.div`
   width: 50%;
   height: 100%;
+  display: flex;
+  justify-content: space-between;
+  @media (max-width: ${MOBILE_WIDTH}px) {
+    width: 100%;
+    max-width: 30rem;
+    height: 2rem;
+  }
 `;

--- a/src/components/UI_common/Button.tsx
+++ b/src/components/UI_common/Button.tsx
@@ -2,22 +2,23 @@ import { ComponentProps } from 'react';
 import styled from 'styled-components';
 import { theme } from '../../styles/theme';
 
-export default function Button(props: ComponentProps<any>) {
-  return <Container {...props} />;
+export default function Button(props: ComponentProps<any> & { color: string }) {
+  return <Container {...props} color={props.color} />;
 }
 
-const Container = styled.button`
-  color: ${theme.primaryDarkColor};
+const Container = styled.button<{ color?: string }>`
+  color: ${(props) => (props.color ? props.color : theme.primaryDarkColor)};
   padding: 0.2rem 0.5rem;
-  border: 1px solid ${theme.primaryDarkColor};
+  border: 1px solid ${(props) => (props.color ? props.color : theme.primaryDarkColor)};
   border-radius: 10px;
   cursor: pointer;
   display: flex;
   justify-content: center;
   align-items: center;
   transition: background-color 0.1s, color 0.1s;
+
   &:hover {
-    background-color: ${theme.primaryDarkColor};
+    background-color: ${(props) => (props.color ? props.color : theme.primaryDarkColor)};
     color: white;
   }
 `;

--- a/src/consts/consts.ts
+++ b/src/consts/consts.ts
@@ -1,3 +1,5 @@
 export const MOBILE_WIDTH = 720;
 export const DEBOUNCER_DELAY_TIME = 500;
 export const ITEMS_PER_PAGE = 30;
+export const VIEW_MODE = { SINGLE: true, MULTIPLE: false };
+export const ISSUE_STATE = { OPEN: 'open', CLOSED: 'closed' } as const;

--- a/src/fetch_modules/issues/useIssuesRequest.tsx
+++ b/src/fetch_modules/issues/useIssuesRequest.tsx
@@ -1,6 +1,7 @@
 import { githubService } from '../../axios/reposService';
 import { ITEMS_PER_PAGE } from '../../consts/consts';
-import { IncomingIssueData, Issue, IssueOpenOrClosedState } from '../../types/data';
+import { IncomingIssueData, Issue } from '../../types/data';
+import { IssueOpenOrClosedState } from '../../types/states';
 import parseIssueData from './parseIssueData';
 
 export default function useIssuesRequest() {

--- a/src/fetch_modules/repos/useReposQuery.tsx
+++ b/src/fetch_modules/repos/useReposQuery.tsx
@@ -10,12 +10,13 @@ export default function useReposQuery() {
   const {
     fetchNextPage,
     isLoading,
+    isFetching,
     isFetchingNextPage,
     hasNextPage,
     isError,
     error,
     data,
-  } = useInfiniteQuery<Repository[]>(
+  } = useInfiniteQuery<Repository[], Error>(
     ['searchedRepos', searchQuery],
     ({ pageParam = 1 }) => (searchQuery ? searchRepos(searchQuery, pageParam) : []),
     {
@@ -26,7 +27,7 @@ export default function useReposQuery() {
       },
       retry: 1,
       refetchOnWindowFocus: false,
-      keepPreviousData: true,
+
       getNextPageParam: (lastPage, allPages) => {
         return !lastPage || lastPage.length < ITEMS_PER_PAGE
           ? undefined
@@ -35,15 +36,13 @@ export default function useReposQuery() {
     },
   );
 
-  const searchedRepos: Repository[] | undefined =
-    data && data.pages ? data.pages.flat() : undefined;
-
   return {
     searchQuery,
     setSearchQuery,
-    searchedRepos,
+    data,
     fetchNextPage,
     isLoading,
+    isFetching,
     isFetchingNextPage,
     hasNextPage,
     isError,

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -4,7 +4,9 @@ import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import { saveReposState } from '../atoms/reposState';
 import IssuesBox from '../components/Issues/IssuesBox';
+import { MOBILE_WIDTH, VIEW_MODE } from '../consts/consts';
 import { theme } from '../styles/theme';
+import { ViewMode } from '../types/states';
 
 export default function IssuesPage() {
   const { repoId: selectedRepoId } = useParams();
@@ -12,45 +14,55 @@ export default function IssuesPage() {
   const getRepoNameById = (repoId: string) =>
     savedRepos.find((repo) => repo.id === Number(repoId))?.fullName;
   const [expandedRepoId, setExpandedRepoId] = useState<null | number>();
+  const viewMode = !!selectedRepoId ? VIEW_MODE.SINGLE : VIEW_MODE.MULTIPLE;
+
   return (
-    <Container hasManyChildren={!selectedRepoId}>
-      {selectedRepoId ? (
-        <IssuesBox
-          repoIndex={savedRepos.findIndex((repo) => repo.id === Number(selectedRepoId))}
-          repoName={getRepoNameById(selectedRepoId)}
-          expanded={true}
-        />
-      ) : (
-        savedRepos.map((repo, index) => (
-          <IssuesBox
-            key={repo.id}
-            repoName={repo.fullName}
-            expanded={expandedRepoId === repo.id}
-            repoIndex={index}
-            onExpandCallback={() =>
-              setExpandedRepoId(expandedRepoId === repo.id ? null : repo.id)
-            }
-          />
-        ))
-      )}
+    <Container viewMode={viewMode}>
+      {viewMode === VIEW_MODE.SINGLE
+        ? selectedRepoId && (
+            <IssuesBox
+              repoName={getRepoNameById(selectedRepoId)}
+              viewMode={VIEW_MODE.SINGLE}
+              isExpanded={true}
+              repoIndex={savedRepos.findIndex(
+                (repo) => repo.id === Number(selectedRepoId),
+              )}
+            />
+          )
+        : savedRepos.map((repo, index) => (
+            <IssuesBox
+              key={repo.id}
+              repoName={repo.fullName}
+              viewMode={VIEW_MODE.MULTIPLE}
+              isExpanded={expandedRepoId === repo.id}
+              repoIndex={index}
+              onExpandCallback={() =>
+                setExpandedRepoId(expandedRepoId === repo.id ? null : repo.id)
+              }
+            />
+          ))}
     </Container>
   );
 }
 
-const Container = styled.div<{ hasManyChildren: boolean }>`
+const Container = styled.div<{ viewMode: ViewMode }>`
   width: 96%;
-  height: calc(100vh - 6rem);
-  margin: 1rem;
+  min-height: calc(100vh - 6rem);
+  height: fit-content;
+  margin: 2%;
   position: relative;
   background-color: ${theme.backgroundColor};
-  display: ${(props) => (props.hasManyChildren ? 'grid' : 'block')};
-  gap: 1rem;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
   justify-content: space-between;
+  gap: 1rem;
 
-  > * {
-    height: ${(props) =>
-      props.hasManyChildren ? 'calc((100vh - 10rem) / 2) ' : 'calc(100vh - 10rem)'};
+  @media (min-width: ${MOBILE_WIDTH}px) {
+    display: ${(props) => (props.viewMode === VIEW_MODE.MULTIPLE ? 'grid' : 'block')};
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+
+  @media (max-width: ${MOBILE_WIDTH}px) {
+    display: flex;
+    flex-direction: column;
   }
 `;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -61,7 +61,7 @@ footer, header, hgroup, menu, nav, section {
 }
 body {
     line-height: 1;
-    height: 100vh;
+    min-height: 100vh;
 }
 #root {
   height: 100%;
@@ -100,7 +100,7 @@ textarea {
   font-family: inherit;
 }
 ::-webkit-scrollbar {
-  width: 12px;  
+  width: 0.5rem;  
 }
 ::-webkit-scrollbar-track {
   background: rgba(0,0,0,0.3);
@@ -110,11 +110,8 @@ textarea {
   background-color: rgba(0,0,0,0.5);   
   border-radius: 5px;
 }
-@media (max-width: 720px) {
-    button {
-      padding: 0.5rem;
-    }
-}
+
+
 
 @-webkit-keyframes skeleton-gradient {
     0% {

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -1,3 +1,5 @@
+import { IssueOpenOrClosedState } from './states';
+
 export type IncomingIssueData = {
   id: number;
   number: number;
@@ -30,9 +32,6 @@ export type Issue = {
   html_url: string;
 };
 export type Issues = { [id: string]: Issue[] | [] };
-
-export const ISSUE_STATE = { OPEN: 'open', CLOSED: 'closed' } as const;
-export type IssueOpenOrClosedState = typeof ISSUE_STATE[keyof typeof ISSUE_STATE];
 
 export type IncomingRepositoryData = {
   id: number;

--- a/src/types/states.ts
+++ b/src/types/states.ts
@@ -1,0 +1,4 @@
+import { ISSUE_STATE, VIEW_MODE } from '../consts/consts';
+
+export type ViewMode = typeof VIEW_MODE[keyof typeof VIEW_MODE];
+export type IssueOpenOrClosedState = typeof ISSUE_STATE[keyof typeof ISSUE_STATE];


### PR DESCRIPTION
## 수정사항
-  명칭 변경: GNB -> Top Nav
- Top Nav: 작은화면 - tablet & mobile (max-width: 720px) 일때 app title 과 search input box 를 행 분리
<img width="382" alt="Screen Shot 2022-09-28 at 6 59 17 PM" src="https://user-images.githubusercontent.com/69628701/192750741-62a1fe43-9ca7-470c-978d-c5a80d9bfcd2.png">

- Repo Search Result Dropdown: 작은 화면에서 width 100% 로 가시성 향상
<img width="375" alt="Screen Shot 2022-09-28 at 6 59 28 PM" src="https://user-images.githubusercontent.com/69628701/192750804-e1524ae3-f232-4469-9950-655ba38ac7bb.png">

- Issues Page: 작은 화면에서 Issue Box 레이아웃을 flex-direction: column 으로 변경
<img width="377" alt="Screen Shot 2022-09-28 at 6 59 53 PM" src="https://user-images.githubusercontent.com/69628701/192750836-1a7b451a-133c-4db4-b70e-5b5979e2c97d.png">

- issues Box: show all 인 상태에서 작은 화면에서 확장 아이콘 클릭 시 세로 40포 -> 80vh 로 확장 / single repository 모드일 경우 한 페이지 전체로 확장
<img width="379" alt="Screen Shot 2022-09-28 at 7 00 09 PM" src="https://user-images.githubusercontent.com/69628701/192750856-21297798-7758-44b5-8922-0bbe59562458.png">
