### PR TITLE
[REFACTOR] fetching 이 필요한 컴포넌트들에 React.lazy 적용 #15

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import Router from "./router";
-import { GlobalStyle } from "./styles/GlobalStyle";
+import Router from './router';
+import { GlobalStyle } from './styles/GlobalStyle';
 
 function App() {
   return (

--- a/src/components/Issues/IssuesBox.tsx
+++ b/src/components/Issues/IssuesBox.tsx
@@ -39,13 +39,9 @@ export default function IssuesBox({
     page: 1,
   });
 
-  const { hasNextPage, isError, ...queryState } = useIssuesQuery(repoName, optionsState);
+  const { hasNextPage, ...queryState } = useIssuesQuery(repoName, optionsState);
 
-  return isError ? (
-    <Container>
-      <ErrorMessage>데이터를 가져오는데 문제가 있습니다.</ErrorMessage>
-    </Container>
-  ) : (
+  return (
     <Container isExpanded={isExpanded} viewMode={viewMode}>
       <SubContainer isExpanded={isExpanded} index={repoIndex}>
         <TitleSection color={theme.repoColor[repoIndex]}>
@@ -60,7 +56,9 @@ export default function IssuesBox({
           optionsState={optionsState}
           setOptionsState={setOptionsState}
         />
-        {queryState.data && <IssuesSection viewMode={viewMode} queryState={queryState} />}
+
+        <IssuesSection viewMode={viewMode} queryState={queryState} />
+
         <PageNavSection
           page={optionsState.page}
           hasNextPage={hasNextPage}
@@ -104,6 +102,7 @@ const Container = styled.div<{ isExpanded?: boolean; viewMode?: ViewMode }>`
 const SubContainer = styled.div<{ isExpanded: boolean; index: number }>`
   border: 1px solid ${theme.borderColor};
   border-radius: 5px;
+  overflow: hidden;
   width: 100%;
   height: 100%;
   display: flex;

--- a/src/components/Issues/sections/IssuesSection.tsx
+++ b/src/components/Issues/sections/IssuesSection.tsx
@@ -14,10 +14,11 @@ export default function IssuesSection({
     data: Issue[] | undefined;
     isLoading: boolean;
     isFetching: boolean;
+    isError: boolean;
   };
   viewMode: ViewMode;
 }) {
-  const { data: issues, isLoading, isFetching } = queryState;
+  const { data: issues, isLoading, isFetching, isError } = queryState;
   const containerRef = useRef<HTMLTableSectionElement>(null);
 
   useEffect(() => {
@@ -27,14 +28,26 @@ export default function IssuesSection({
 
   return (
     <Container ref={containerRef}>
-      <IssuesContainer>
-        {(isLoading || isFetching) &&
-          new Array(5).fill(null).map((_, index) => <IssueItem key={index} />)}
-        {issues &&
-          !isLoading &&
-          !isFetching &&
-          issues.map((issue) => <IssueItem key={issue.id} data={issue} />)}
-      </IssuesContainer>
+      {(isLoading || isFetching) && (
+        <IssuesContainer>
+          {new Array(5).fill(null).map((_, index) => (
+            <IssueItem key={index} />
+          ))}
+        </IssuesContainer>
+      )}
+      {issues &&
+        !isLoading &&
+        !isFetching &&
+        (issues.length > 0 ? (
+          <IssuesContainer>
+            {issues.map((issue) => (
+              <IssueItem key={issue.id} data={issue} />
+            ))}
+          </IssuesContainer>
+        ) : (
+          <NoIssues>No Issues</NoIssues>
+        ))}
+      {isError && <NoIssues>데이터를 가져오는데 문제가 있습니다.</NoIssues>}
     </Container>
   );
 }
@@ -57,4 +70,12 @@ const IssuesContainer = styled.div`
   > *:last-child {
     border-bottom: none;
   }
+`;
+
+const NoIssues = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,23 +1,28 @@
 import { Outlet } from 'react-router-dom';
-import Main from './Main';
-import TopNav from './TopNav/TopNav';
-import RepositoriesNav from './RepositoriesNav';
 import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { lazy, Suspense } from 'react';
+import { LoadingPage } from '../pages/LoadingPage';
 // import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+const TopNav = lazy(() => import('./TopNav/TopNav'));
+const RepositoriesNav = lazy(() => import('./RepositoriesNav'));
+const Main = lazy(() => import('./Main'));
 
 export default function Layout() {
   const queryClient = new QueryClient();
   return (
-    <RecoilRoot>
-      <QueryClientProvider client={queryClient}>
-        {/* <ReactQueryDevtools /> */}
-        <TopNav />
-        <RepositoriesNav />
-        <Main>
-          <Outlet />
-        </Main>
-      </QueryClientProvider>
-    </RecoilRoot>
+    <Suspense fallback={<LoadingPage />}>
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          {/* <ReactQueryDevtools /> */}
+          <TopNav />
+          <RepositoriesNav />
+          <Main>
+            <Outlet />
+          </Main>
+        </QueryClientProvider>
+      </RecoilRoot>
+    </Suspense>
   );
 }

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,9 +1,14 @@
-import { ReactNode } from 'react';
+import { ReactNode, Suspense } from 'react';
 import styled from 'styled-components';
+import { LoadingPage } from '../pages/LoadingPage';
 import { theme } from '../styles/theme';
 
 export default function Main({ children }: { children: ReactNode }) {
-  return <Container>{children}</Container>;
+  return (
+    <Suspense fallback={<LoadingPage />}>
+      <Container>{children}</Container>
+    </Suspense>
+  );
 }
 
 const Container = styled.main`

--- a/src/pages/LoadingPage.tsx
+++ b/src/pages/LoadingPage.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+import { theme } from '../styles/theme';
+
+export function LoadingPage() {
+  return <Container>Loading...</Container>;
+}
+
+const Container = styled.div`
+  width: 100vw;
+  height: 100vh;
+  background-color: ${theme.primaryBackgroundColor};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,7 +1,7 @@
-import { BrowserRouter, Route, Routes } from "react-router-dom";
-import Layout from "./components/Layout";
-import IssuesPage from "./pages/IssuesPage";
-import { PageNotFound } from "./pages/PageNotFound";
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import Layout from './components/Layout';
+import IssuesPage from './pages/IssuesPage';
+import { PageNotFound } from './pages/PageNotFound';
 
 export default function Router() {
   return (


### PR DESCRIPTION
## 개선사항

- FCP 시간 개선을 위해 Top Nav, Repositories Nav, Main 에 React.lazy 적용하여 code splitting #15 
- 기존:
<img width="1395" alt="Screen Shot 2022-10-05 at 5 57 50 PM" src="https://user-images.githubusercontent.com/69628701/194046698-24bbaab4-9037-4b82-b892-8a7b294bbd1c.png">

- 개선 후:

<img width="1920" alt="Screen Shot 2022-10-05 at 7 09 23 PM" src="https://user-images.githubusercontent.com/69628701/194046742-3c50b96e-1800-4bd2-8944-94aad288fdf8.png">

- LCP(largest contentful paint) 는 현재 6.9초 이나 해당되는 문제들이 라이브러리들의 unused javascript 부분이어서 build 과정의 tree shaking  후 해결 될 사항들로 판단 됨.

<img width="712" alt="Screen Shot 2022-10-05 at 8 08 40 PM" src="https://user-images.githubusercontent.com/69628701/194047570-5a1d2470-873e-447c-a297-aa79b8ef6b3c.png">
