### PR TITLE
[FEAT] 모바일 화면 UI 개선 - #20 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
+import { RecoilRoot } from 'recoil';
 import Router from './router';
 import { GlobalStyle } from './styles/GlobalStyle';
 
 function App() {
   return (
     <>
-      <GlobalStyle />
-      <Router />
+      <RecoilRoot>
+        <GlobalStyle />
+        <Router />
+      </RecoilRoot>
     </>
   );
 }

--- a/src/UI_hooks/useIntersectionObserver.ts
+++ b/src/UI_hooks/useIntersectionObserver.ts
@@ -16,7 +16,7 @@ export default function useIntersectionObserver(
   React.useEffect(() => {
     const options = {
       root: rootRef.current,
-      rootMargin: '0px',
+      rootMargin: '200px',
       threshold: 0,
     };
     const observer = new IntersectionObserver(onIntersection, options);

--- a/src/UI_hooks/useIntersectionObserver.ts
+++ b/src/UI_hooks/useIntersectionObserver.ts
@@ -8,6 +8,7 @@ export default function useIntersectionObserver(
 ) {
   const onIntersection = (entries: IntersectionObserverEntry[]) => {
     if (entries[0].isIntersecting) {
+      console.log('intersecting...');
       callback();
     }
   };
@@ -15,7 +16,7 @@ export default function useIntersectionObserver(
   React.useEffect(() => {
     const options = {
       root: rootRef.current,
-      rootMargin: '200px',
+      rootMargin: '0px',
       threshold: 0,
     };
     const observer = new IntersectionObserver(onIntersection, options);

--- a/src/UI_hooks/useSwipe.ts
+++ b/src/UI_hooks/useSwipe.ts
@@ -1,0 +1,47 @@
+import { RefObject, useEffect } from 'react';
+
+const useSwipe = (
+  targetRef: RefObject<HTMLDivElement>,
+  scrollLength: number,
+  direction: 'x' | 'y',
+) => {
+  useEffect(() => {
+    const startPoint = { x: 0, y: 0 };
+
+    const onTouchStart = (event: TouchEvent) => (
+      (startPoint.x = event.changedTouches[0].clientX),
+      (startPoint.y = event.changedTouches[0].clientY)
+    );
+
+    const onTouchEnd = (event: TouchEvent) => {
+      const offset = {
+        x: startPoint.x - event.changedTouches[0].clientX,
+        y: startPoint.y - event.changedTouches[0].clientY,
+      };
+      console.log(offset);
+      direction === 'y' &&
+        Math.abs(offset.y) > Math.abs(offset.x) &&
+        targetRef.current?.scrollTo({
+          top: targetRef.current.scrollTop + (offset.y / Math.abs(offset.y)) * scrollLength,
+          behavior: 'smooth',
+        });
+
+      direction === 'x' &&
+        Math.abs(offset.x) > Math.abs(offset.y) &&
+        targetRef.current?.scrollTo({
+          left: targetRef.current.scrollLeft + (offset.x / Math.abs(offset.x)) * scrollLength,
+          behavior: 'smooth',
+        });
+    };
+
+    targetRef.current && targetRef.current.addEventListener('touchstart', onTouchStart);
+    targetRef.current && targetRef.current.addEventListener('touchend', onTouchEnd);
+
+    return () => {
+      targetRef.current?.removeEventListener('touchstart', onTouchStart);
+      targetRef.current?.removeEventListener('touchend', onTouchEnd);
+    };
+  }, []);
+};
+
+export default useSwipe;

--- a/src/atoms/reposState.ts
+++ b/src/atoms/reposState.ts
@@ -10,9 +10,7 @@ const localStorageEffect =
     }
 
     onSet((newValue, _, isReset) => {
-      isReset
-        ? localStorage.removeItem(key)
-        : localStorage.setItem(key, JSON.stringify(newValue));
+      isReset ? localStorage.removeItem(key) : localStorage.setItem(key, JSON.stringify(newValue));
     });
   };
 

--- a/src/atoms/screenSizeState.ts
+++ b/src/atoms/screenSizeState.ts
@@ -1,0 +1,19 @@
+import { atom, selector, useRecoilValue } from 'recoil';
+import { MOBILE_WIDTH } from '../consts/consts';
+
+export const screenSizeState = atom<number>({
+  key: 'screenSize',
+  default: 0,
+  effects: [
+    ({ setSelf }) => {
+      setSelf(window.innerWidth);
+    },
+  ],
+});
+
+export const mediaType = selector({
+  key: 'mediaType',
+  get: ({ get }) => (get(screenSizeState) <= MOBILE_WIDTH ? 'mobile' : 'desktop/tablet'),
+});
+
+export const useMediaType = () => useRecoilValue(mediaType);

--- a/src/components/Issues/IssuesBoxMobile.tsx
+++ b/src/components/Issues/IssuesBoxMobile.tsx
@@ -29,11 +29,8 @@ export default function IssuesBoxMobile({
   const [page, setPage] = useState(1);
   const rootRef = useRef(null);
   const bottomDetectorRef = useRef(null);
-  const { data, hasNextPage, isLoading, isFetching, isFetchingNextPage, isError } = useIssuesQuery(
-    repoName,
-    issuesOpenOrClosed,
-    page,
-  );
+  const { data, hasNextPageInfiniteQuery, isLoading, isFetching, isFetchingNextPage, isError } =
+    useIssuesQuery(repoName, issuesOpenOrClosed, page);
   const issues = data?.pages.flat();
   console.log(page);
 
@@ -59,8 +56,8 @@ export default function IssuesBoxMobile({
             <LoadingSpinner color={theme.primaryDarkColor} />
           </SpinnerWrapper>
         )}
-        {hasNextPage && !isFetchingNextPage && (
-          <BottomDetector ref={bottomDetectorRef}>Detector</BottomDetector>
+        {hasNextPageInfiniteQuery && !isFetchingNextPage && (
+          <BottomDetector ref={bottomDetectorRef} />
         )}
       </IssuesSection>
     </Container>

--- a/src/components/Issues/IssuesBoxMobile.tsx
+++ b/src/components/Issues/IssuesBoxMobile.tsx
@@ -1,0 +1,124 @@
+import { useRef, useState } from 'react';
+import styled from 'styled-components';
+import { ISSUE_STATE } from '../../consts/consts';
+import useIssuesQuery from '../../fetch_modules/issues/useIssuesQuery';
+import { theme } from '../../styles/theme';
+import { IssueOpenOrClosedState } from '../../types/states';
+import useIntersectionObserver from '../../UI_hooks/useIntersectionObserver';
+import LoadingSpinner from '../UI_common/LoadingSpinner';
+import IssuesSection from './sections/IssuesSection';
+import IssuesToolbarSection from './sections/IssuesToolbarSection';
+
+export default function IssuesBoxMobile({
+  repoName,
+  repoIndex,
+}: {
+  repoName: string | undefined;
+  repoIndex: number;
+}) {
+  if (repoName === undefined)
+    return (
+      <Container>
+        <ErrorMessage>해당 리포지토리를 찾을 수 없습니다.</ErrorMessage>
+      </Container>
+    );
+
+  const [issuesOpenOrClosed, setIssuesOpenOrClosed] = useState<IssueOpenOrClosedState>(
+    ISSUE_STATE.OPEN,
+  );
+  const [page, setPage] = useState(1);
+  const rootRef = useRef(null);
+  const bottomDetectorRef = useRef(null);
+  const { data, hasNextPage, isLoading, isFetching, isFetchingNextPage, isError } = useIssuesQuery(
+    repoName,
+    issuesOpenOrClosed,
+    page,
+  );
+  const issues = data?.pages.flat();
+  console.log(page);
+
+  useIntersectionObserver(bottomDetectorRef, rootRef, () => setPage(page + 1), [data]);
+
+  return (
+    <Container ref={rootRef}>
+      <TitleSection color={theme.repoColor[repoIndex]}>
+        <RepoTitle>{repoName}</RepoTitle>
+      </TitleSection>
+      <IssuesToolbarSection
+        issuesOpenOrClosed={issuesOpenOrClosed}
+        toggleOpenOrClosed={(issuesOpenOrClosed) => setIssuesOpenOrClosed(issuesOpenOrClosed)}
+      />
+
+      <IssuesSection
+        issues={issues}
+        queryState={{ isLoading, isError }}
+        shouldScrollTopOnUpdate={false}
+      >
+        {(isLoading || isFetching || isFetchingNextPage) && (
+          <SpinnerWrapper>
+            <LoadingSpinner color={theme.primaryDarkColor} />
+          </SpinnerWrapper>
+        )}
+        {hasNextPage && !isFetchingNextPage && (
+          <BottomDetector ref={bottomDetectorRef}>Detector</BottomDetector>
+        )}
+      </IssuesSection>
+    </Container>
+  );
+}
+
+const ErrorMessage = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Container = styled.div<{ isExpanded?: boolean }>`
+  width: 100vw;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  > * {
+    border-bottom: 0.5px solid ${theme.borderColor};
+    padding: 0.5rem;
+  }
+  > *:last-child,
+  > *:first-child {
+    border-bottom: none;
+  }
+`;
+
+const TitleSection = styled.section`
+  width: 100%;
+  min-height: 1.4375rem;
+  height: 1.4375rem;
+  padding: 0 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  color: white;
+  background-color: ${(props) => props.color};
+  position: relative;
+`;
+const RepoTitle = styled.div`
+  height: 100%;
+  display: flex;
+  align-items: center;
+`;
+
+const BottomDetector = styled.div`
+  width: 100%;
+  height: 10px;
+`;
+
+const SpinnerWrapper = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/components/Issues/sections/IssuesSection.tsx
+++ b/src/components/Issues/sections/IssuesSection.tsx
@@ -1,43 +1,41 @@
-import { useEffect, useRef } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import IssueItem from '../IssueItem';
-import { VIEW_MODE } from '../../../consts/consts';
 import { theme } from '../../../styles/theme';
 import { Issue } from '../../../types/data';
-import { ViewMode } from '../../../types/states';
 
 export default function IssuesSection({
+  shouldScrollTopOnUpdate,
+  issues,
   queryState,
-  viewMode,
+  children,
 }: {
+  shouldScrollTopOnUpdate: boolean;
+  issues: Issue[] | undefined;
   queryState: {
-    data: Issue[] | undefined;
     isLoading: boolean;
-    isFetching: boolean;
     isError: boolean;
   };
-  viewMode: ViewMode;
+  children?: ReactNode;
 }) {
-  const { data: issues, isLoading, isFetching, isError } = queryState;
+  const { isLoading, isError } = queryState;
   const containerRef = useRef<HTMLTableSectionElement>(null);
 
   useEffect(() => {
-    if (containerRef.current) containerRef.current.scrollTop = 0;
-    if (viewMode === VIEW_MODE.SINGLE) window.scrollTo(0, 0);
+    containerRef.current && shouldScrollTopOnUpdate && (containerRef.current.scrollTop = 0);
   }, [issues]);
 
   return (
     <Container ref={containerRef}>
-      {(isLoading || isFetching) && (
+      {isLoading && (
         <IssuesContainer>
-          {new Array(5).fill(null).map((_, index) => (
+          {new Array(10).fill(null).map((_, index) => (
             <IssueItem key={index} />
           ))}
         </IssuesContainer>
       )}
       {issues &&
         !isLoading &&
-        !isFetching &&
         (issues.length > 0 ? (
           <IssuesContainer>
             {issues.map((issue) => (
@@ -48,6 +46,7 @@ export default function IssuesSection({
           <NoIssues>No Issues</NoIssues>
         ))}
       {isError && <NoIssues>데이터를 가져오는데 문제가 있습니다.</NoIssues>}
+      {children}
     </Container>
   );
 }
@@ -55,7 +54,10 @@ export default function IssuesSection({
 const Container = styled.section`
   width: 100%;
   height: 100%;
-  overflow: auto;
+  min-height: 0;
+
+  overflow-y: auto;
+  -webkit-overflow-scrolling-y: auto;
 `;
 
 const IssuesContainer = styled.ul`

--- a/src/components/Issues/sections/IssuesToolbarSection.tsx
+++ b/src/components/Issues/sections/IssuesToolbarSection.tsx
@@ -1,37 +1,28 @@
-import { Dispatch } from 'react';
 import styled from 'styled-components';
 import { ISSUE_STATE } from '../../../consts/consts';
 import { theme } from '../../../styles/theme';
 import { IssueOpenOrClosedState } from '../../../types/states';
-import { IssueOptions } from './../IssuesBox';
 
 export default function IssuesToolbarSection({
-  optionsState,
-  setOptionsState,
+  issuesOpenOrClosed,
+  toggleOpenOrClosed,
 }: {
-  optionsState: IssueOptions;
-  setOptionsState: Dispatch<IssueOptions>;
+  issuesOpenOrClosed: IssueOpenOrClosedState;
+  toggleOpenOrClosed: (issueOpenOrClosed: IssueOpenOrClosedState) => void;
 }) {
-  const toggleIssueStateFilter = (issueState: IssueOpenOrClosedState) => {
-    setOptionsState({
-      openOrClosed: issueState,
-      page: 1,
-    });
-  };
-
   return (
     <Container>
       <div>Issue State: </div>
       <ChooseStateButtons>
         <IssueStateButton
-          selected={optionsState.openOrClosed === ISSUE_STATE.OPEN}
-          onClick={() => toggleIssueStateFilter(ISSUE_STATE.OPEN)}
+          selected={issuesOpenOrClosed === ISSUE_STATE.OPEN}
+          onClick={() => toggleOpenOrClosed(ISSUE_STATE.OPEN)}
         >
           OPEN
         </IssueStateButton>
         <IssueStateButton
-          selected={optionsState.openOrClosed === ISSUE_STATE.CLOSED}
-          onClick={() => toggleIssueStateFilter(ISSUE_STATE.CLOSED)}
+          selected={issuesOpenOrClosed === ISSUE_STATE.CLOSED}
+          onClick={() => toggleOpenOrClosed(ISSUE_STATE.CLOSED)}
         >
           CLOSED
         </IssueStateButton>

--- a/src/components/Issues/sections/PageNavSection.tsx
+++ b/src/components/Issues/sections/PageNavSection.tsx
@@ -4,22 +4,23 @@ import Button from '../../UI_common/Button';
 export default function PageNavSection({
   page,
   hasNextPage,
+  isFetchingNextPage,
   setPage,
 }: {
   page: number;
-  hasNextPage: boolean | 'pending';
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
   setPage: (page: number) => void;
 }) {
   return (
     <Container>
       {page > 1 && <PrevButton onClick={() => setPage(page - 1)}>&lt; Previous Page</PrevButton>}
       Page {page}
-      {hasNextPage &&
-        (hasNextPage === true ? (
-          <NextButton onClick={() => setPage(page + 1)}>Next Page &gt;</NextButton>
-        ) : (
-          <LoadingText>Loading...</LoadingText>
-        ))}
+      {isFetchingNextPage ? (
+        <LoadingText>Loading...</LoadingText>
+      ) : (
+        hasNextPage && <NextButton onClick={() => setPage(page + 1)}>Next Page &gt;</NextButton>
+      )}
     </Container>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { lazy, Suspense, useEffect } from 'react';
 import { LoadingPage } from '../pages/LoadingPage';
 import { Toaster } from 'react-hot-toast';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+// import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { screenSizeState, useMediaType } from '../atoms/screenSizeState';
 import IssuesPageMobile from '../pages/IssuesPageMobile';
 import { useSetRecoilState } from 'recoil';
@@ -25,7 +25,7 @@ export default function Layout() {
   return (
     <Suspense fallback={<LoadingPage />}>
       <QueryClientProvider client={queryClient}>
-        <ReactQueryDevtools />
+        {/* <ReactQueryDevtools /> */}
         <TopNav />
         <RepositoriesNav />
         <Main>{mediaType === 'desktop/tablet' ? <Outlet /> : <IssuesPageMobile />}</Main>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,10 +1,12 @@
 import { Outlet } from 'react-router-dom';
-import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { LoadingPage } from '../pages/LoadingPage';
 import { Toaster } from 'react-hot-toast';
-// import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { screenSizeState, useMediaType } from '../atoms/screenSizeState';
+import IssuesPageMobile from '../pages/IssuesPageMobile';
+import { useSetRecoilState } from 'recoil';
 
 const TopNav = lazy(() => import('./TopNav/TopNav'));
 const RepositoriesNav = lazy(() => import('./RepositoriesNav'));
@@ -12,19 +14,23 @@ const Main = lazy(() => import('./Main'));
 
 export default function Layout() {
   const queryClient = new QueryClient();
+  const setScreenSize = useSetRecoilState(screenSizeState);
+  const mediaType = useMediaType();
+  useEffect(() => {
+    const onWindowResize = () => setScreenSize(window.innerWidth);
+    window.addEventListener('resize', onWindowResize);
+    return () => window.removeEventListener('resize', onWindowResize);
+  }, []);
+
   return (
     <Suspense fallback={<LoadingPage />}>
-      <RecoilRoot>
-        <QueryClientProvider client={queryClient}>
-          {/* <ReactQueryDevtools /> */}
-          <TopNav />
-          <RepositoriesNav />
-          <Main>
-            <Outlet />
-          </Main>
-          <Toaster />
-        </QueryClientProvider>
-      </RecoilRoot>
+      <QueryClientProvider client={queryClient}>
+        <ReactQueryDevtools />
+        <TopNav />
+        <RepositoriesNav />
+        <Main>{mediaType === 'desktop/tablet' ? <Outlet /> : <IssuesPageMobile />}</Main>
+        <Toaster />
+      </QueryClientProvider>
     </Suspense>
   );
 }

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -10,6 +10,8 @@ const Container = styled.main`
   display: flex;
   flex-direction: column;
   justify-content: stretch;
-  height: calc(100% - 6rem);
+  height: 100%;
+  width: 100%;
+  min-height: 0;
   background-color: ${theme.primaryBackgroundColor};
 `;

--- a/src/components/RepositoriesNav.tsx
+++ b/src/components/RepositoriesNav.tsx
@@ -10,7 +10,6 @@ import { MOBILE_WIDTH } from '../consts/consts';
 export default function RepositoriesNav() {
   const [savedRepos, setSavedRepos] = useRecoilState(saveReposState);
   const navigate = useNavigate();
-
   const navigateToSingleRepoPage = (repoId: number) => navigate(`/${repoId}`);
   const navigateToShowAllPage = () => navigate(`/`);
   const removeRepo = (repoIdToRemove: number) => {
@@ -35,8 +34,9 @@ export default function RepositoriesNav() {
           />
         </Item>
       ))}
+
       <ButtonWrapper>
-        <ShowAllButton onClick={navigateToShowAllPage} title="show all button" />
+        <ShowAllButton onClick={navigateToShowAllPage} />{' '}
       </ButtonWrapper>
     </Container>
   );
@@ -49,11 +49,19 @@ const Container = styled.ul`
   display: flex;
   padding: 0.5rem 1rem;
   gap: 1rem;
+  @media (max-width: ${MOBILE_WIDTH}px) {
+    padding: 0.3rem 0.5rem;
+    gap: 1%;
+  }
 `;
 
 const ButtonWrapper = styled.li`
   width: 18%;
   margin-left: auto;
+
+  @media (max-width: ${MOBILE_WIDTH}px) {
+    display: none;
+  }
 `;
 const ShowAllButton = styled(Button)`
   width: 100%;
@@ -77,9 +85,22 @@ const Item = styled.li<{ color: string }>`
   align-items: center;
   justify-content: space-between;
   padding: 0.2rem 0.5rem;
+  position: relative;
+
   @media (max-width: ${MOBILE_WIDTH}px) {
     padding: 0.2rem 0.2rem;
     font-size: 0.8rem;
+    width: 24%;
+    &::before {
+      content: '';
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      top: 50%;
+      left: 0;
+      z-index: -1;
+      background-color: ${(props) => props.color};
+    }
   }
 `;
 const RepoName = styled.div`

--- a/src/components/TopNav/RepoSearchResult.tsx
+++ b/src/components/TopNav/RepoSearchResult.tsx
@@ -118,6 +118,7 @@ const Container = styled.ul`
   @media (max-width: ${MOBILE_WIDTH}px) {
     width: 100%;
     left: 0;
+    font-size: 0.8rem;
   }
 `;
 

--- a/src/components/TopNav/RepoSearchResult.tsx
+++ b/src/components/TopNav/RepoSearchResult.tsx
@@ -39,14 +39,18 @@ export default function RepoSearchResultDropdown({
   const [alert, setAlert] = useState({ isShowing: false, message: '' });
 
   const saveRepo = (repo: Repository) => {
-    if (savedRepos.length < 4) {
-      setSavedRepos([...savedRepos, repo]);
-      close();
-    } else
-      setAlert({
+    if (savedRepos.length === 4)
+      return setAlert({
         isShowing: true,
         message: '리포지토리 저장 가능 한도(4개)를 초과했어요.',
       });
+    if (savedRepos.some((savedRepo) => savedRepo.id === repo.id))
+      return setAlert({
+        isShowing: true,
+        message: '같은 리포지토리가 이미 존재합니다.',
+      });
+    setSavedRepos([...savedRepos, repo]);
+    close();
   };
 
   const onAlertDialogConfirm = (isConfirmed: boolean) =>
@@ -78,10 +82,7 @@ export default function RepoSearchResultDropdown({
         flattenedPage.map((repo) => <RepoItem key={repo.id} repo={repo} saveRepo={saveRepo} />)
       ) : isLoading || isFetching ? (
         <SpinnerWrapper>
-          <LoadingSpinner
-            color={theme.primaryColor}
-            backgroundColor={theme.secondaryBackgroundColor}
-          />
+          <LoadingSpinner color={theme.primaryDarkColor} />
         </SpinnerWrapper>
       ) : (
         <Status>No Results</Status>

--- a/src/components/UI_common/LoadingSpinner.tsx
+++ b/src/components/UI_common/LoadingSpinner.tsx
@@ -1,37 +1,15 @@
 import styled from 'styled-components';
 
-export default function LoadingSpinner({
-  color,
-  backgroundColor,
-}: {
-  color: string;
-  backgroundColor: string;
-}) {
-  return (
-    <Container backgroundColor={backgroundColor}>
-      <MainCircle color={color}>
-        <Triangle backgroundColor={backgroundColor} />
-      </MainCircle>
-    </Container>
-  );
+export default function LoadingSpinner({ color }: { color: string }) {
+  return <MainCircle color={color} />;
 }
 
-const Container = styled.div<{ backgroundColor: string }>`
-  width: 6rem;
-  height: 6rem;
-  transform: scale(0.5);
-  transform-origin: top;
-  background-color: ${(props) => props.backgroundColor};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
 const MainCircle = styled.div<{ color: string }>`
-  width: 4rem;
-  height: 4rem;
+  width: 3rem;
+  height: 3rem;
   position: relative;
-  border: 10px solid ${(props) => props.color};
-  box-sizing: border-box;
+  border: 7px solid ${(props) => props.color};
+  border-top: 7px solid transparent;
   border-radius: 50%;
   animation: 0.8s infinite linear rotate;
 
@@ -43,15 +21,4 @@ const MainCircle = styled.div<{ color: string }>`
       transform: rotate(360deg);
     }
   }
-`;
-
-const Triangle = styled.div<{ backgroundColor: string }>`
-  width: 0;
-  height: 0;
-  left: -10px;
-  top: -10px;
-  border-top: 2rem solid ${(props) => props.backgroundColor};
-  border-left: 2rem solid transparent;
-  border-right: 2rem solid transparent;
-  position: absolute;
 `;

--- a/src/fetch_modules/issues/useIssuesQuery.tsx
+++ b/src/fetch_modules/issues/useIssuesQuery.tsx
@@ -1,48 +1,59 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import useIssuesRequest from './useIssuesRequest';
-import { useLayoutEffect, useState } from 'react';
-import { IssueOptions } from '../../components/Issues/IssuesBox';
 import toast from 'react-hot-toast';
 import { Issue } from '../../types/data';
 import { AxiosError } from 'axios';
 import { ERROR_MESSAGE } from '../../consts/errors';
+import { ITEMS_PER_PAGE } from '../../consts/consts';
+import { IssueOpenOrClosedState } from '../../types/states';
+import { useLayoutEffect, useState } from 'react';
 
-export default function useIssuesQuery(repoName: string, selectedOptions: IssueOptions) {
-  const [hasNextPage, setHasNextPage] = useState<boolean | 'pending'>(false);
-  const { openOrClosed, page } = selectedOptions;
-
+export default function useIssuesQuery(
+  repoName: string,
+  openOrClosed: IssueOpenOrClosedState,
+  currentPage: number,
+) {
   const { getIssuesByRepoName } = useIssuesRequest();
-  const queryClient = useQueryClient();
+  const [hasNextPage, setHasNextPage] = useState<boolean>(false);
 
-  const { isLoading, isFetching, isError, data } = useQuery<Issue[], AxiosError>(
-    ['issues', repoName, openOrClosed, page],
-    () => getIssuesByRepoName(repoName, openOrClosed, page),
-    {
-      retry: (failureCount, error) =>
-        !(error.message === ERROR_MESSAGE.API_REQUEST_LIMIT_EXCEEDED || failureCount > 1),
-      staleTime: 60 * 1000,
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-      onError: (error) => toast.error('Issues fetch failed: ' + error.message, { duration: 3000 }),
-    },
-  );
+  const getHasNextPage = (data: Issue[][]) =>
+    data.length === currentPage &&
+    fetchNextPage({ pageParam: currentPage + 1 }).then((result) => {
+      console.log('next page fetched:', result);
+      setHasNextPage(
+        (result?.data?.pages[currentPage] && result.data.pages[currentPage].length > 0) || false,
+      );
+    });
+
+  const { fetchNextPage, isLoading, isFetching, isFetchingNextPage, isError, error, data } =
+    useInfiniteQuery<Issue[], AxiosError>(
+      ['issues', repoName, openOrClosed],
+      ({ pageParam = 1 }) => getIssuesByRepoName(repoName, openOrClosed, pageParam),
+      {
+        retry: (failureCount, error) =>
+          !(error.message === ERROR_MESSAGE.API_REQUEST_LIMIT_EXCEEDED || failureCount > 1),
+        staleTime: 60 * 1000,
+        refetchOnWindowFocus: false,
+        refetchOnMount: false,
+        onSuccess: (data) => getHasNextPage(data?.pages),
+        onError: (error) =>
+          toast.error('Issues fetch failed: ' + error.message, { duration: 3000 }),
+        getNextPageParam: (lastPage, allPages) =>
+          !lastPage || lastPage.length < ITEMS_PER_PAGE ? undefined : allPages.length + 1,
+      },
+    );
 
   useLayoutEffect(() => {
-    setHasNextPage('pending');
-    queryClient
-      .fetchQuery(['issues', repoName, openOrClosed, page + 1], () =>
-        getIssuesByRepoName(repoName, openOrClosed, page + 1),
-      )
-      .then((data) => {
-        setHasNextPage(data.length > 0);
-      })
-      .catch(() => setHasNextPage(false));
-  }, [data]);
+    data && getHasNextPage(data.pages);
+  }, [currentPage]);
 
   return {
+    fetchNextPage,
     isLoading,
     isFetching,
+    isFetchingNextPage,
     isError,
+    error,
     data,
     hasNextPage,
   };

--- a/src/fetch_modules/issues/useIssuesQuery.tsx
+++ b/src/fetch_modules/issues/useIssuesQuery.tsx
@@ -25,23 +25,30 @@ export default function useIssuesQuery(
       );
     });
 
-  const { fetchNextPage, isLoading, isFetching, isFetchingNextPage, isError, error, data } =
-    useInfiniteQuery<Issue[], AxiosError>(
-      ['issues', repoName, openOrClosed],
-      ({ pageParam = 1 }) => getIssuesByRepoName(repoName, openOrClosed, pageParam),
-      {
-        retry: (failureCount, error) =>
-          !(error.message === ERROR_MESSAGE.API_REQUEST_LIMIT_EXCEEDED || failureCount > 1),
-        staleTime: 60 * 1000,
-        refetchOnWindowFocus: false,
-        refetchOnMount: false,
-        onSuccess: (data) => getHasNextPage(data?.pages),
-        onError: (error) =>
-          toast.error('Issues fetch failed: ' + error.message, { duration: 3000 }),
-        getNextPageParam: (lastPage, allPages) =>
-          !lastPage || lastPage.length < ITEMS_PER_PAGE ? undefined : allPages.length + 1,
-      },
-    );
+  const {
+    fetchNextPage,
+    isLoading,
+    isFetching,
+    isFetchingNextPage,
+    isError,
+    error,
+    data,
+    hasNextPage: hasNextPageInfiniteQuery,
+  } = useInfiniteQuery<Issue[], AxiosError>(
+    ['issues', repoName, openOrClosed],
+    ({ pageParam = 1 }) => getIssuesByRepoName(repoName, openOrClosed, pageParam),
+    {
+      retry: (failureCount, error) =>
+        !(error.message === ERROR_MESSAGE.API_REQUEST_LIMIT_EXCEEDED || failureCount > 1),
+      staleTime: 60 * 1000,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      onSuccess: (data) => getHasNextPage(data?.pages),
+      onError: (error) => toast.error('Issues fetch failed: ' + error.message, { duration: 3000 }),
+      getNextPageParam: (lastPage, allPages) =>
+        !lastPage || lastPage.length < ITEMS_PER_PAGE ? undefined : allPages.length + 1,
+    },
+  );
 
   useLayoutEffect(() => {
     data && getHasNextPage(data.pages);
@@ -56,5 +63,6 @@ export default function useIssuesQuery(
     error,
     data,
     hasNextPage,
+    hasNextPageInfiniteQuery,
   };
 }

--- a/src/fetch_modules/repos/useReposQuery.tsx
+++ b/src/fetch_modules/repos/useReposQuery.tsx
@@ -31,6 +31,7 @@ export default function useReposQuery() {
       retry: (failureCount, error) =>
         !(error.message === ERROR_MESSAGE.API_REQUEST_LIMIT_EXCEEDED || failureCount > 1),
       refetchOnWindowFocus: false,
+      refetchOnMount: false,
       onError: (error) =>
         toast.error('Repository search failed: ' + error.message, { duration: 3000 }),
       getNextPageParam: (lastPage, allPages) => {

--- a/src/pages/IssuesPage.tsx
+++ b/src/pages/IssuesPage.tsx
@@ -1,52 +1,26 @@
-import { useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import { saveReposState } from '../atoms/reposState';
 import IssuesBox from '../components/Issues/IssuesBox';
-import { MOBILE_WIDTH, VIEW_MODE } from '../consts/consts';
 import { theme } from '../styles/theme';
-import { ViewMode } from '../types/states';
 
 export default function IssuesPage() {
   const { repoId: selectedRepoId } = useParams();
   const savedRepos = useRecoilValue(saveReposState);
-  const [expandedRepoId, setExpandedRepoId] = useState<null | number>();
-  const viewMode = !!selectedRepoId ? VIEW_MODE.SINGLE : VIEW_MODE.MULTIPLE;
-
-  const getRepoNameById = (repoId: string | undefined) =>
-    repoId && savedRepos.find((repo) => repo.id === Number(repoId))?.fullName;
-
-  const selectedRepoName = useMemo(
-    () => getRepoNameById(selectedRepoId),
-    [selectedRepoId],
-  );
+  const navigate = useNavigate();
 
   return savedRepos.length > 0 ? (
-    <Container viewMode={viewMode}>
-      {viewMode === VIEW_MODE.SINGLE
-        ? selectedRepoName && (
-            <IssuesBox
-              repoName={selectedRepoName}
-              viewMode={VIEW_MODE.SINGLE}
-              isExpanded={true}
-              repoIndex={savedRepos.findIndex(
-                (repo) => repo.id === Number(selectedRepoId),
-              )}
-            />
-          )
-        : savedRepos.map((repo, index) => (
-            <IssuesBox
-              key={repo.id}
-              repoName={repo.fullName}
-              viewMode={VIEW_MODE.MULTIPLE}
-              isExpanded={expandedRepoId === repo.id}
-              repoIndex={index}
-              onExpandCallback={() =>
-                setExpandedRepoId(expandedRepoId === repo.id ? null : repo.id)
-              }
-            />
-          ))}
+    <Container>
+      {savedRepos.map((repo, index) => (
+        <IssuesBox
+          key={repo.id}
+          repoName={repo.fullName}
+          isExpanded={Number(selectedRepoId) === repo.id}
+          repoIndex={index}
+          onExpandCallback={() => navigate(`/${Number(selectedRepoId) === repo.id ? '' : repo.id}`)}
+        />
+      ))}
     </Container>
   ) : (
     <NoRepositories>
@@ -56,31 +30,25 @@ export default function IssuesPage() {
   );
 }
 
-const Container = styled.div<{ viewMode: ViewMode }>`
-  width: 100%;
+const Container = styled.div`
   padding: 1rem;
-  min-height: calc(100vh - 6rem);
+
   margin: auto;
   position: relative;
+  height: 100%;
   background-color: ${theme.primaryBackgroundColor};
+  display: flex;
   justify-content: space-between;
   align-items: stretch;
+
+  width: 100%;
+  flex-wrap: wrap;
 
   > *:nth-child(3) {
     align-self: flex-end;
   }
   > *:nth-child(4) {
     align-self: flex-end;
-  }
-  @media (min-width: ${MOBILE_WIDTH}px) {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
-  @media (max-width: ${MOBILE_WIDTH}px) {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
   }
 `;
 

--- a/src/pages/IssuesPageMobile.tsx
+++ b/src/pages/IssuesPageMobile.tsx
@@ -1,0 +1,62 @@
+import { useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import styled from 'styled-components';
+import { saveReposState } from '../atoms/reposState';
+import IssuesBoxMobile from '../components/Issues/IssuesBoxMobile';
+import { theme } from '../styles/theme';
+import { screenSizeState } from '../atoms/screenSizeState';
+import { useEffect, useRef } from 'react';
+import useSwipe from '../UI_hooks/useSwipe';
+
+export default function IssuesPageMobile() {
+  const savedRepos = useRecoilValue(saveReposState);
+  const { repoId: selectedRepoId } = useParams();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const screenWidth = useRecoilValue(screenSizeState);
+  console.log('issue page rendering...');
+
+  useEffect(() => {
+    containerRef.current &&
+      containerRef.current.scrollTo({
+        left: savedRepos.findIndex((repo) => repo.id === Number(selectedRepoId)) * screenWidth,
+        behavior: 'smooth',
+      });
+  }, [selectedRepoId]);
+
+  useSwipe(containerRef, screenWidth, 'x');
+
+  return savedRepos.length > 0 ? (
+    <Container ref={containerRef}>
+      <IssuesContainer>
+        {savedRepos.map((repo, index) => (
+          <IssuesBoxMobile key={repo.id} repoName={repo.fullName} repoIndex={index} />
+        ))}
+      </IssuesContainer>
+    </Container>
+  ) : (
+    <NoRepositories>
+      {' '}
+      <h2>Search &#38; Add Repositories</h2>
+    </NoRepositories>
+  );
+}
+
+const Container = styled.div`
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  background-color: ${theme.primaryBackgroundColor};
+`;
+const IssuesContainer = styled.div`
+  display: flex;
+  width: fit-content;
+  height: 100%;
+`;
+const NoRepositories = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  opacity: 0.5;
+`;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -16,6 +16,7 @@ export const GlobalStyle = createGlobalStyle`
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+
 }
 * {
   box-sizing: border-box;
@@ -53,6 +54,7 @@ time, mark, audio, video {
     border: 0;
     vertical-align: baseline;
     list-style: none;
+    overscroll-behavior: none;
 }
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure, 
@@ -64,7 +66,10 @@ body {
     min-height: 100vh;
 }
 #root {
-  height: 100%;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
 }
 ol, ul {
     list-style: none;

--- a/src/types/states.ts
+++ b/src/types/states.ts
@@ -1,4 +1,4 @@
-import { ISSUE_STATE, VIEW_MODE } from '../consts/consts';
+import { ISSUE_STATE } from '../consts/consts';
 
-export type ViewMode = typeof VIEW_MODE[keyof typeof VIEW_MODE];
+export type MediaType = 'mobile' | 'desktop/tablet';
 export type IssueOpenOrClosedState = typeof ISSUE_STATE[keyof typeof ISSUE_STATE];

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,6 +1,0 @@
-export const sortByDate = (data: any[], key: string, order: "asc" | "desc") =>
-  data.sort((a, b) =>
-    order === "asc"
-      ? new Date(a[key]).getTime() - new Date(b[key]).getTime()
-      : new Date(b[key]).getTime() - new Date(a[key]).getTime()
-  );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()]
-})
+  plugins: [react()],
+});


### PR DESCRIPTION
#20 - 모바일 화면 UI 개선

## 변경사항
- 기존화면:
<img width="377" alt="Screen Shot 2022-09-28 at 6 59 53 PM" src="https://user-images.githubusercontent.com/69628701/194732746-804f5061-1061-4ea4-ae4b-33d27dc8e987.png">
- 변경 후:

![Kapture 2022-10-09 at 10 19 12](https://user-images.githubusercontent.com/69628701/194733236-7992656c-eb80-4d54-9c3c-10acfac431e2.gif)

- 모바일 화면 UI: 기존의 issue box들은 한 화면에 세로 정렬 -> 한 화면에 한 리포만 보여주고 Repository Nav에서 탭 선택 또는 스와이핑으로 다른 리포로 이동하는 것으로 변경
- useIssuesQuery: useQuery 에서 useInfiniteQuery로 변경. 기존의 페이지 각각 따로 쿼리를 저장하는 방식에서 같은 리포에 대한 데이터를 page 배열로 저장하면 다음 페이지를 미리 펫칭하여 hasNextPage 를 판별하는 로직이 간편해진다고 판단. 
- pagination: 모바일 화면에선 따로 페이지 이동 없이 Infinite Scroll 적용
- screen size: media query 만 사용하여 감지하는 방식에서 전역으로 onresize 이벤트 감지하여 recoil 전역 상태로 저장하여 관리하는 것으로 변경. 모바일 화면의 UI가 데스크탑과 많이 다른 부분들은 컴포넌트 재활용 보다 따로 컴포넌트를 구현하는 것이 가독성이 좋다고 판단. (IssuesPageMobile, IssuesBoxMobile 두 컴포넌트 분리)
- Single/Multiple repo mode: Single 모드는 multiple(Show All) 모드에서 확장 버튼을 눌러 하나의 리포가 확장된 화면과 크게 다르지 않아 모드 변경 기능 자체를 삭제(모바일/데스크탑 모두). 라우팅에 의한 리포선택은 아직 유효하며 param으로 확장되는 리포를 결정
